### PR TITLE
Added option for passing in a alternate servePath for generating CDN urls

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,56 +1,51 @@
 (function() {
   var BEFORE_DOT, ConnectAssets, EXPLICIT_PATH, REMOTE_PATH, Snockets, connectCache, crypto, cssCompilers, cssExts, fs, jsCompilers, libs, md5Filenamer, mkdirRecursive, parse, path, stripExt, timeEq, _;
-  var __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
+
   connectCache = require('connect-file-cache');
+
   Snockets = require('snockets');
+
   crypto = require('crypto');
+
   fs = require('fs');
+
   path = require('path');
+
   _ = require('underscore');
+
   parse = require('url').parse;
+
   libs = {};
+
   module.exports = function(options) {
-    var connectAssets, _base, _ref, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
-    if (options == null) {
-      options = {};
-    }
-    if (connectAssets) {
-      return connectAssets;
-    }
-    if ((_ref = options.src) == null) {
-      options.src = 'assets';
-    }
-    if ((_ref2 = options.helperContext) == null) {
-      options.helperContext = global;
-    }
+    var connectAssets, _base, _ref, _ref10, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
+    if (options == null) options = {};
+    if (connectAssets) return connectAssets;
+    if ((_ref = options.src) == null) options.src = 'assets';
+    if ((_ref2 = options.helperContext) == null) options.helperContext = global;
     if (process.env.NODE_ENV === 'production') {
-      if ((_ref3 = options.build) == null) {
-        options.build = true;
-      }
+      if ((_ref3 = options.build) == null) options.build = true;
       if ((_ref4 = (_base = cssCompilers.styl).compress) == null) {
         _base.compress = true;
       }
+      if ((_ref5 = options.servePath) == null) options.servePath = '';
+    } else {
+      options.servePath = '';
     }
-    if ((_ref5 = options.buildDir) == null) {
-      options.buildDir = 'builtAssets';
-    }
-    if ((_ref6 = options.buildFilenamer) == null) {
+    if ((_ref6 = options.buildDir) == null) options.buildDir = 'builtAssets';
+    if ((_ref7 = options.buildFilenamer) == null) {
       options.buildFilenamer = md5Filenamer;
     }
-    if ((_ref7 = options.buildsExpire) == null) {
-      options.buildsExpire = false;
-    }
-    if ((_ref8 = options.detectChanges) == null) {
-      options.detectChanges = true;
-    }
-    if ((_ref9 = options.minifyBuilds) == null) {
-      options.minifyBuilds = true;
-    }
+    if ((_ref8 = options.buildsExpire) == null) options.buildsExpire = false;
+    if ((_ref9 = options.detectChanges) == null) options.detectChanges = true;
+    if ((_ref10 = options.minifyBuilds) == null) options.minifyBuilds = true;
     connectAssets = module.exports.instance = new ConnectAssets(options);
     connectAssets.createHelpers(options);
     return connectAssets.cache.middleware;
   };
+
   ConnectAssets = (function() {
+
     function ConnectAssets(options) {
       this.options = options;
       this.cache = connectCache();
@@ -62,19 +57,17 @@
       this.buildFilenames = {};
       this.cachedRoutePaths = {};
     }
+
     ConnectAssets.prototype.createHelpers = function() {
       var context, expandRoute, srcIsRemote;
+      var _this = this;
       context = this.options.helperContext;
       srcIsRemote = this.options.src.match(REMOTE_PATH);
       expandRoute = function(shortRoute, ext, rootDir) {
-        if (context.js.root[0] === '/') {
-          context.js.root = context.js.root.slice(1);
-        }
+        if (context.js.root[0] === '/') context.js.root = context.js.root.slice(1);
         if (shortRoute.match(EXPLICIT_PATH)) {
           if (!shortRoute.match(REMOTE_PATH)) {
-            if (shortRoute[0] === '/') {
-              shortRoute = shortRoute.slice(1);
-            }
+            if (shortRoute[0] === '/') shortRoute = shortRoute.slice(1);
           }
         } else {
           shortRoute = path.join(rootDir, shortRoute);
@@ -84,36 +77,35 @@
         }
         return shortRoute;
       };
-      context.css = __bind(function(route) {
+      context.css = function(route) {
         route = expandRoute(route, '.css', context.css.root);
-        if (!route.match(REMOTE_PATH)) {
-          route = this.compileCSS(route);
-        }
+        if (!route.match(REMOTE_PATH)) route = _this.compileCSS(route);
         return "<link rel='stylesheet' href='" + route + "'>";
-      }, this);
+      };
       context.css.root = 'css';
-      context.js = __bind(function(route) {
+      context.js = function(route) {
         var r, routes;
         route = expandRoute(route, '.js', context.js.root);
         if (route.match(REMOTE_PATH)) {
           routes = [route];
         } else if (srcIsRemote) {
-          routes = ["" + this.options.src + "/" + route];
+          routes = ["" + _this.options.src + "/" + route];
         } else {
-          routes = this.compileJS(route);
+          routes = _this.compileJS(route);
         }
         return ((function() {
           var _i, _len, _results;
           _results = [];
           for (_i = 0, _len = routes.length; _i < _len; _i++) {
             r = routes[_i];
-            _results.push("<script src='" + r + "'></script>");
+            _results.push("<script src='" + this.options.servePath + r + "'></script>");
           }
           return _results;
-        })()).join('\n');
-      }, this);
+        }).call(_this)).join('\n');
+      };
       return context.js.root = 'js';
     };
+
     ConnectAssets.prototype.compileCSS = function(route) {
       var alreadyCached, buildPath, cacheFlags, css, data, ext, filename, mtime, source, sourcePath, startTime, stats, _i, _len, _ref, _ref2, _ref3, _ref4;
       if (!this.options.detectChanges && this.cachedRoutePaths[route]) {
@@ -198,8 +190,10 @@
       }
       throw new Error("No file found for route " + route);
     };
+
     ConnectAssets.prototype.compileJS = function(route) {
       var callback, chain, ext, filename, js, snocketsFlags, sourcePath, _i, _len, _ref;
+      var _this = this;
       if (!this.options.detectChanges && this.cachedRoutePaths[route]) {
         return this.cachedRoutePaths[route];
       }
@@ -217,28 +211,26 @@
         try {
           if (this.options.build) {
             filename = null;
-            callback = __bind(function(err, concatenation, changed) {
+            callback = function(err, concatenation, changed) {
               var buildDir, buildPath, cacheFlags;
-              if (err) {
-                throw err;
-              }
+              if (err) throw err;
               if (changed) {
-                filename = this.options.buildFilenamer(route, concatenation);
-                this.buildFilenames[sourcePath] = filename;
+                filename = _this.options.buildFilenamer(route, concatenation);
+                _this.buildFilenames[sourcePath] = filename;
                 cacheFlags = {
-                  expires: this.options.buildsExpire
+                  expires: _this.options.buildsExpire
                 };
-                this.cache.set(filename, concatenation, cacheFlags);
-                if (buildDir = this.options.buildDir) {
+                _this.cache.set(filename, concatenation, cacheFlags);
+                if (buildDir = _this.options.buildDir) {
                   buildPath = path.join(process.cwd(), buildDir, filename);
                   return mkdirRecursive(path.dirname(buildPath), 0755, function(err) {
                     return fs.writeFile(buildPath, concatenation);
                   });
                 }
               } else {
-                return filename = this.buildFilenames[sourcePath];
+                return filename = _this.buildFilenames[sourcePath];
               }
-            }, this);
+            };
             snocketsFlags = {
               minify: this.options.minifyBuilds,
               async: false
@@ -271,6 +263,7 @@
       }
       throw new Error("No file found for route " + route);
     };
+
     ConnectAssets.prototype.absPath = function(route) {
       if (this.options.src.match(EXPLICIT_PATH)) {
         return path.join(this.options.src, route);
@@ -278,8 +271,11 @@
         return path.join(process.cwd(), this.options.src, route);
       }
     };
+
     return ConnectAssets;
+
   })();
+
   exports.cssCompilers = cssCompilers = {
     styl: {
       optionsMap: {},
@@ -287,9 +283,7 @@
         var callback, options, result, _base, _ref;
         result = '';
         callback = function(err, js) {
-          if (err) {
-            throw err;
-          }
+          if (err) throw err;
           return result = js;
         };
         libs.stylus || (libs.stylus = require('stylus'));
@@ -311,10 +305,15 @@
       }
     }
   };
+
   exports.jsCompilers = jsCompilers = Snockets.compilers;
+
   BEFORE_DOT = /([^.]*)(\..*)?$/;
+
   EXPLICIT_PATH = /^\/|\/\//;
+
   REMOTE_PATH = /\/\//;
+
   stripExt = function(filePath) {
     var lastDotIndex;
     if ((lastDotIndex = filePath.lastIndexOf('.')) >= 0) {
@@ -323,6 +322,7 @@
       return filePath;
     }
   };
+
   cssExts = function() {
     var ext;
     return ((function() {
@@ -334,24 +334,23 @@
       return _results;
     })()).concat('.css');
   };
+
   timeEq = function(date1, date2) {
     return (date1 != null) && (date2 != null) && date1.getTime() === date2.getTime();
   };
+
   mkdirRecursive = function(dir, mode, callback) {
     var pathParts;
     pathParts = path.normalize(dir).split('/');
     return path.exists(dir, function(exists) {
-      if (exists) {
-        return callback(null);
-      }
+      if (exists) return callback(null);
       return mkdirRecursive(pathParts.slice(0, -1).join('/'), mode, function(err) {
-        if (err && err.errno !== process.EEXIST) {
-          return callback(err);
-        }
+        if (err && err.errno !== process.EEXIST) return callback(err);
         return fs.mkdir(dir, mode, callback);
       });
     });
   };
+
   exports.md5Filenamer = md5Filenamer = function(filename, code) {
     var ext, hash, md5Hex;
     hash = crypto.createHash('md5');
@@ -360,4 +359,5 @@
     ext = path.extname(filename);
     return "" + (stripExt(filename)) + "-" + md5Hex + ext;
   };
+
 }).call(this);

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -18,12 +18,15 @@ module.exports = (options = {}) ->
   if process.env.NODE_ENV is 'production'
     options.build ?= true
     cssCompilers.styl.compress ?= true
+    options.servePath ?= ''
+  else
+    options.servePath = ''
   options.buildDir ?= 'builtAssets'
   options.buildFilenamer ?= md5Filenamer
   options.buildsExpire ?= false
   options.detectChanges ?= true
   options.minifyBuilds ?= true
-
+  
   connectAssets = module.exports.instance = new ConnectAssets options
   connectAssets.createHelpers options
   connectAssets.cache.middleware
@@ -73,7 +76,7 @@ class ConnectAssets
         routes = ["#{@options.src}/#{route}"]
       else
         routes = @compileJS route
-      ("<script src='#{r}'></script>" for r in routes).join '\n'
+      ("<script src='#{@options.servePath}#{r}'></script>" for r in routes).join '\n'
     context.js.root = 'js'
 
   # Synchronously compile Stylus to CSS (if needed) and return the route


### PR DESCRIPTION
When we go to production, we want to server our static assets out of a CDN with one common CDN across multiple apps.  We need to be able to pass in the CDN url as the basepath for all asset resolution.
