### PR TITLE
Needed support for generating hashed names for image files

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,5 +1,5 @@
 (function() {
-  var BEFORE_DOT, ConnectAssets, EXPLICIT_PATH, REMOTE_PATH, Snockets, connectCache, crypto, cssCompilers, cssExts, fs, jsCompilers, libs, md5Filenamer, mkdirRecursive, parse, path, stripExt, timeEq, _;
+  var BEFORE_DOT, ConnectAssets, EXPLICIT_PATH, REMOTE_PATH, Snockets, connectCache, crypto, cssCompilers, cssExts, fs, getExt, jsCompilers, libs, md5Filenamer, mkdirRecursive, parse, path, stripExt, timeEq, _;
 
   connectCache = require('connect-file-cache');
 
@@ -72,7 +72,7 @@
         } else {
           shortRoute = path.join(rootDir, shortRoute);
         }
-        if (shortRoute.indexOf(ext, shortRoute.length - ext.length) === -1) {
+        if (ext && shortRoute.indexOf(ext, shortRoute.length - ext.length) === -1) {
           shortRoute += ext;
         }
         return shortRoute;
@@ -103,7 +103,68 @@
           return _results;
         }).call(_this)).join('\n');
       };
-      return context.js.root = 'js';
+      context.js.root = 'js';
+      context.img = function(route) {
+        var routes;
+        route = expandRoute(route, null, context.img.root);
+        console.log(route);
+        if (route.match(REMOTE_PATH)) {
+          routes = route;
+        } else if (srcIsRemote) {
+          route = "" + _this.options.src + "/" + route;
+        } else {
+          route = _this.cacheImg(route);
+        }
+        return "" + _this.options.servePath + route;
+      };
+      return context.img.root = 'img';
+    };
+
+    ConnectAssets.prototype.cacheImg = function(route) {
+      var alreadyCached, buildPath, cacheFlags, filename, img, mtime, sourcePath, stats, _ref;
+      if (!this.options.detectChanges && this.cachedRoutePaths[route]) {
+        return this.cachedRoutePaths[route];
+      }
+      sourcePath = route;
+      try {
+        stats = fs.statSync(this.absPath(sourcePath));
+        if (timeEq(mtime, (_ref = this.cache.map[route]) != null ? _ref.mtime : void 0)) {
+          alreadyCached = true;
+        } else {
+          mtime = stats.mtime;
+          img = fs.readFileSync(this.absPath(sourcePath));
+        }
+        if (alreadyCached && this.options.build) {
+          filename = this.buildFilenames[sourcePath];
+          return "/" + filename;
+        } else if (alreadyCached) {
+          return "/" + route;
+        } else if (this.options.build) {
+          filename = this.options.buildFilenamer(route, getExt(route));
+          console.log("fileName=" + filename);
+          this.buildFilenames[sourcePath] = filename;
+          cacheFlags = {
+            expires: this.options.buildsExpire,
+            mtime: mtime
+          };
+          this.cache.set(filename, img, cacheFlags);
+          if (this.options.buildDir) {
+            buildPath = path.join(process.cwd(), this.options.buildDir, filename);
+            mkdirRecursive(path.dirname(buildPath), 0755, function() {
+              return fs.writeFile(buildPath, img);
+            });
+          }
+          return this.cachedRoutePaths[route] = "/" + filename;
+        } else {
+          this.cache.set(route, img, {
+            mtime: mtime
+          });
+          return this.cachedRoutePaths[route] = "/" + route;
+        }
+      } catch (e) {
+        console.info(e);
+      }
+      throw new Error("No file found for route " + route);
     };
 
     ConnectAssets.prototype.compileCSS = function(route) {
@@ -313,6 +374,14 @@
   EXPLICIT_PATH = /^\/|\/\//;
 
   REMOTE_PATH = /\/\//;
+
+  getExt = function(filePath) {
+    var lastDotIndex;
+    if ((lastDotIndex = filePath.lastIndexOf('.')) >= 0) {
+      filePath.slice(lastDotIndex + 1);
+    }
+    return '';
+  };
 
   stripExt = function(filePath) {
     var lastDotIndex;


### PR DESCRIPTION
Added an img function that will generate the hash for an image file and return the hashed name just like it does for css and js files.  Not sure if there was a reason that this wasn't included already.  If there is a reason not to do this or to do this some other way, I'd love to know.
