### PR TITLE
Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,13 @@
     "underscore": "1.1.7"
   },
   "devDependencies": {
-    "async": "0.1.14",
+    "async": "~> 0.1.14",
     "coffee-script": "1.1.2",
-    "connect": "1.6.4",
-    "nib": "0.2.0",
-    "nodeunit": "0.5.4",
-    "stylus": "0.19.0",
-    "request": "2.1.1",
-    "watchit": ">=0.0.1"
+    "connect": "~> 1.8.5",
+    "nib": "~> 0.3.2",
+    "nodeunit": "~> 0.6.4",
+    "stylus": "~> 0.22.0",
+    "request": "~> 2.9.3",
+    "watchit": "~> 0.0.1"
   }
 }


### PR DESCRIPTION
connect 1.6.4 was incompatible with node 0.6, so I bumped and relaxed all the development dependencies (except coffee-script, which fails a bunch of tests with >1.1.2).
