### PR TITLE
Option to provide only paths from helper

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -37,6 +37,7 @@
     if (options.buildsExpire == null) options.buildsExpire = false;
     if (options.detectChanges == null) options.detectChanges = true;
     if (options.minifyBuilds == null) options.minifyBuilds = true;
+    if (options.pathsOnly == null) options.pathsOnly = false;
     jsCompilers = _.extend(jsCompilers, options.jsCompilers || {});
     connectAssets = module.exports.instance = new ConnectAssets(options);
     connectAssets.createHelpers(options);
@@ -76,19 +77,17 @@
         }
         return shortRoute;
       };
-      context.css = function(route, opts) {
-        if (opts == null) opts = {};
+      context.css = function(route) {
         route = expandRoute(route, '.css', context.css.root);
         if (!route.match(REMOTE_PATH)) {
           route = _this.options.servePath + _this.compileCSS(route);
         }
-        if (opts.path_only) return route;
+        if (_this.options.pathsOnly) return route;
         return "<link rel='stylesheet' href='" + route + "'>";
       };
       context.css.root = 'css';
-      context.js = function(route, opts) {
+      context.js = function(route) {
         var p, r, routes;
-        if (opts == null) opts = {};
         route = expandRoute(route, '.js', context.js.root);
         if (route.match(REMOTE_PATH)) {
           routes = [route];
@@ -106,7 +105,7 @@
             return _results;
           }).call(_this);
         }
-        if (opts.paths_only) return routes;
+        if (_this.options.pathsOnly) return routes;
         return ((function() {
           var _i, _len, _results;
           _results = [];

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -27,6 +27,7 @@ module.exports = exports = (options = {}) ->
   options.buildsExpire ?= false
   options.detectChanges ?= true
   options.minifyBuilds ?= true
+  options.pathsOnly ?= false
   jsCompilers = _.extend jsCompilers, options.jsCompilers || {}
 
   connectAssets = module.exports.instance = new ConnectAssets options
@@ -63,17 +64,15 @@ class ConnectAssets
         shortRoute += ext
       shortRoute
 
-    context.css = (route, opts) =>
-      opts ?= {}
+    context.css = (route) =>
       route = expandRoute route, '.css', context.css.root
       unless route.match REMOTE_PATH
         route = @options.servePath + @compileCSS route
-      return route if opts.path_only
+      return route if @options.pathsOnly
       "<link rel='stylesheet' href='#{route}'>"
     context.css.root = 'css'
 
-    context.js = (route, opts) =>
-      opts ?= {}
+    context.js = (route) =>
       route = expandRoute route, '.js', context.js.root
       if route.match REMOTE_PATH
         routes = [route]
@@ -82,7 +81,7 @@ class ConnectAssets
       else
         routes = (@options.servePath + p for p in @compileJS route)
 
-      return routes if opts.paths_only
+      return routes if @options.pathsOnly
       ("<script src='#{r}'></script>" for r in routes).join '\n'
     context.js.root = 'js'
 

--- a/test/DevelopmentIntegration.coffee
+++ b/test/DevelopmentIntegration.coffee
@@ -126,10 +126,6 @@ exports['css helper function provides correct href'] = (test) ->
   test.equals css(url = '//raw.github.com/necolas/normalize.css/master/normalize.css'), "<link rel='stylesheet' href='#{url}'>"
   test.done()
 
-exports['css helper function provides only path when requested'] = (test) ->
-  test.equals css('style', path_only: true), '/css/style.css'
-  test.done()
-
 exports['js helper function provides correct src'] = (test) ->
   jsTag = "<script src='/js/script.js'></script>"
   test.equals js('/js/script.js'), jsTag
@@ -139,14 +135,17 @@ exports['js helper function provides correct src'] = (test) ->
   test.equals js(url = '//code.jquery.com/jquery-1.6.2.js'), "<script src='#{url}'></script>"
   test.done()
 
-exports['js helper function provides array of paths when requested'] = (test) ->
+exports['helper functions provides only paths when requested'] = (test) ->
+  context = {}
+  path_assets = assets helperContext: context, pathsOnly: true
   jsFiles = [
     '/js/js-dependency.js'
     '/js/coffee-dependency.js'
     '/js/more/annoying.1.2.3.js'
     '/js/dependent.js'
   ]
-  test.deepEqual js('dependent', paths_only: true), jsFiles
+  test.deepEqual context.js('dependent'), jsFiles
+  test.equals context.css('style'), '/css/style.css'
   test.done()
 
 exports['Script files can `require` (in non-production mode)'] = (test) ->


### PR DESCRIPTION
I'd like an option to get only the paths to scripts or stylesheets rather than the whole HTML markup.

For example, this is useful in an app using [zappa](http://zappajs.org/), where I want to pass these paths to the default layout:

``` coffee
@render "index", scripts: js("foo", paths_only: true)
```
