### PR TITLE
Updated mkdirRecursive function to by synchronous

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -340,16 +340,11 @@
   mkdirRecursive = function(dir, mode, callback) {
     var pathParts;
     pathParts = path.normalize(dir).split('/');
-    return path.exists(dir, function(exists) {
-      if (exists) {
-        return callback(null);
-      }
-      return mkdirRecursive(pathParts.slice(0, -1).join('/'), mode, function(err) {
-        if (err && err.errno !== process.EEXIST) {
-          return callback(err);
-        }
-        return fs.mkdir(dir, mode, callback);
-      });
+    if (path.existsSync(dir)) return callback(null);
+    return mkdirRecursive(pathParts.slice(0, -1).join('/'), mode, function(err) {
+      if (err && err.errno !== process.EEXIST) return callback(err);
+      fs.mkdirSync(dir, mode);
+      return callback();
     });
   };
   exports.md5Filenamer = md5Filenamer = function(filename, code) {

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -215,11 +215,13 @@ timeEq = (date1, date2) ->
 
 mkdirRecursive = (dir, mode, callback) ->
   pathParts = path.normalize(dir).split '/'
-  path.exists dir, (exists) ->
-    return callback null if exists
-    mkdirRecursive pathParts.slice(0,-1).join('/'), mode, (err) ->
-      return callback err if err and err.errno isnt process.EEXIST
-      fs.mkdir dir, mode, callback
+  if path.existsSync dir
+    return callback null
+    
+  mkdirRecursive pathParts.slice(0,-1).join('/'), mode, (err) ->
+    return callback err if err and err.errno isnt process.EEXIST
+    fs.mkdirSync dir, mode
+    callback()
 
 exports.md5Filenamer = md5Filenamer = (filename, code) ->
   hash = crypto.createHash('md5')


### PR DESCRIPTION
Changed the mkdirRecursive function to be a synchronous operation to match the rest of the implementation.

When this is not synchronous, then some assets failed to be saved
to the `builtAssets` folder if their target folder didn't exist
yet.
