### PR TITLE
Added option for jsCompilers

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -17,6 +17,8 @@
 
   libs = {};
 
+  jsCompilers = Snockets.compilers;
+
   module.exports = exports = function(options) {
     var connectAssets, _base;
     if (options == null) options = {};
@@ -35,6 +37,8 @@
     if (options.buildsExpire == null) options.buildsExpire = false;
     if (options.detectChanges == null) options.detectChanges = true;
     if (options.minifyBuilds == null) options.minifyBuilds = true;
+    jsCompilers = _.extend(jsCompilers, options.jsCompilers || {});
+
     connectAssets = module.exports.instance = new ConnectAssets(options);
     connectAssets.createHelpers(options);
     return connectAssets.cache.middleware;
@@ -389,7 +393,7 @@
     }
   };
 
-  exports.jsCompilers = jsCompilers = Snockets.compilers;
+  exports.jsCompilers = jsCompilers;
 
   BEFORE_DOT = /([^.]*)(\..*)?$/;
 

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -10,6 +10,7 @@ _             = require 'underscore'
 {parse}       = require 'url'
 
 libs = {}
+jsCompilers = Snockets.compilers
 
 module.exports = exports = (options = {}) ->
   return connectAssets if connectAssets
@@ -26,7 +27,8 @@ module.exports = exports = (options = {}) ->
   options.buildsExpire ?= false
   options.detectChanges ?= true
   options.minifyBuilds ?= true
-  
+  jsCompilers = _.extend jsCompilers, options.jsCompilers || {}
+
   connectAssets = module.exports.instance = new ConnectAssets options
   connectAssets.createHelpers options
   connectAssets.cache.middleware
@@ -259,8 +261,7 @@ exports.cssCompilers = cssCompilers =
           .render callback
       result
 
-exports.jsCompilers = jsCompilers = Snockets.compilers
-
+exports.jsCompilers = jsCompilers
 # ## Regexes
 BEFORE_DOT = /([^.]*)(\..*)?$/
 

--- a/test/RemoteIntegration.coffee
+++ b/test/RemoteIntegration.coffee
@@ -3,7 +3,11 @@ request = require 'request'
 
 app = require('connect').createServer()
 assets = require('../lib/assets.js')
-app.use assets src: 'http://mycdn.com'
+app.use assets src: 'http://mycdn.com', jsCompilers:
+  iced:
+    match: /\.js$/
+    compileSync: (sourcePath, source) ->
+      require('coffee-script').compile source, filename: sourcePath
 
 exports['options.src can be a URL'] = (test) ->
   jsTag = "<script src='http://mycdn.com/js/jquery.min.js'></script>"
@@ -14,3 +18,8 @@ exports['If options.src is a URL, other URLs are still allowed'] = (test) ->
   jsTag = "<script src='//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js'></script>"
   test.equals js('//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.1.7/underscore-min.js'), jsTag
   test.done()
+
+exports['jsCompilers can be passed as an option'] = (test) ->
+  test.equals "function", typeof assets.jsCompilers.iced.compileSync
+  test.done()
+


### PR DESCRIPTION
Loving connect-assets!!

Added option for jsCompilers, not a "needed" function as jsCompilers was exported.

Just so the following is now possible (am using zappa) :-

   @use require('connect-assets') src: "#{__dirname}/assets", jsCompilers:
      iced:
        match: /.js$/
        compileSync: (sourcePath, source) ->
          require('iced-coffee-script').compile source, filename: sourcePath
