### PR TITLE
Added LESS support. Make sure that LESS compiles all files synchronously

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,5 +1,5 @@
 (function() {
-  var BEFORE_DOT, ConnectAssets, EXPLICIT_PATH, REMOTE_PATH, Snockets, connectCache, crypto, cssCompilers, cssExts, exports, fs, getExt, jsCompilers, libs, md5Filenamer, mkdirRecursive, parse, path, stripExt, timeEq, _;
+  var BEFORE_DOT, ConnectAssets, EXPLICIT_PATH, REMOTE_PATH, Snockets, connectCache, crypto, cssCompilers, cssExts, exports, fs, getExt, jsCompilers, libs, md5Filenamer, mkdirRecursive, parse, path, stripExt, timeEq, util, _;
 
   connectCache = require('connect-file-cache');
 
@@ -15,12 +15,14 @@
 
   parse = require('url').parse;
 
+  util = require('util');
+
   libs = {};
 
   jsCompilers = Snockets.compilers;
 
   module.exports = exports = function(options) {
-    var connectAssets, _base;
+    var connectAssets, _base, _base2;
     if (options == null) options = {};
     if (connectAssets) return connectAssets;
     if (options.src == null) options.src = 'assets';
@@ -28,6 +30,7 @@
     if (process.env.NODE_ENV === 'production') {
       if (options.build == null) options.build = true;
       if ((_base = cssCompilers.styl).compress == null) _base.compress = true;
+      if ((_base2 = cssCompilers.less).compress == null) _base2.compress = true;
       if (options.servePath == null) options.servePath = '';
     } else {
       options.servePath = '';
@@ -415,7 +418,6 @@
     },
     less: {
       optionsMap: {
-        compress: false,
         optimization: 1,
         silent: false,
         paths: [],
@@ -456,16 +458,18 @@
         return less;
       },
       compileSync: function(sourcePath, source) {
-        var callback, options, result;
+        var callback, compress, options, result, _ref;
         result = "";
         libs.less || (libs.less = this.patchLess(require('less')));
         options = this.optionsMap;
         options.filename = sourcePath;
         options.paths = [path.dirname(sourcePath)].concat(options.paths);
+        compress = (_ref = this.compress) != null ? _ref : false;
         callback = function(err, tree) {
-          if (err) console.log("FEhler", err);
           if (err) throw err;
-          return result = tree.toCSS({});
+          return result = tree.toCSS({
+            compress: compress
+          });
         };
         new libs.less.Parser(options).parse(source, callback);
         return result;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "nodeunit": "0.5.4",
     "stylus": "0.22.2",
     "request": "2.1.1",
-    "watchit": ">=0.0.1"
+    "watchit": ">=0.0.1",
+    "less": "1.3.0"
   }
 }

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -8,6 +8,7 @@ fs            = require 'fs'
 path          = require 'path'
 _             = require 'underscore'
 {parse}       = require 'url'
+util          = require 'util'
 
 libs = {}
 jsCompilers = Snockets.compilers
@@ -19,6 +20,7 @@ module.exports = exports = (options = {}) ->
   if process.env.NODE_ENV is 'production'
     options.build ?= true
     cssCompilers.styl.compress ?= true
+    cssCompilers.less.compress ?= true
     options.servePath ?= ''
   else
     options.servePath = ''
@@ -269,7 +271,6 @@ exports.cssCompilers = cssCompilers =
 
   less:
     optionsMap:
-      compress: false
       optimization: 1
       silent: false
       paths: []
@@ -317,10 +318,11 @@ exports.cssCompilers = cssCompilers =
       options = @optionsMap
       options.filename = sourcePath
       options.paths = [path.dirname(sourcePath)].concat(options.paths)
+      compress = @compress ? false
 
       callback = (err, tree) ->
         throw err if err
-        result = tree.toCSS({})
+        result = tree.toCSS({compress: compress})
 
       new libs.less.Parser(options).parse(source, callback)
       result

--- a/test/DevelopmentIntegration.coffee
+++ b/test/DevelopmentIntegration.coffee
@@ -81,6 +81,21 @@ exports['Stylus imports work as expected'] = (test) ->
     '''
     test.equals body, expectedBody
     test.done()
+    
+exports['Less is served as CSS'] = (test) ->
+  cssTag = "<link rel='stylesheet' href='/css/style-less.css'>"
+  test.equals css('style-less'), cssTag
+  
+  request 'http://localhost:3588/css/style-less.css', (err, res, body) ->
+    throw err if err
+    expectedBody = '''
+    textarea,
+    input {
+      border: 1px solid #eee;
+    }\n
+    '''
+    test.equals body, expectedBody
+    test.done()
 
 exports['nib is supported when available'] = (test) ->
   cssTag = "<link rel='stylesheet' href='/css/gradient.css'>"

--- a/test/assets/css/style-less.less
+++ b/test/assets/css/style-less.less
@@ -1,0 +1,3 @@
+textarea, input {
+  border: 1px solid #eee;
+}


### PR DESCRIPTION
These changes should make sure, that connect-assets can show less files.

I tried this with the complete Twitter bootstrap, and it worked without any problems.
Maybe we should add some unit testcases, too?
