### PR TITLE
fixed mkdirRecursive for Windows

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -555,18 +555,36 @@
     return (date1 != null) && (date2 != null) && date1.getTime() === date2.getTime();
   };
 
-  mkdirRecursive = function(dir, mode, callback) {
-    var pathParts;
-    pathParts = path.normalize(dir).split('/');
-    if (path.existsSync(dir)) {
-      return callback(null);
+  mkdirRecursive = function(dir, mode, callback, position) {
+    mode = mode || 0777;
+    position = position || 0;
+    parts = require('path').normalize(path).split('/');
+
+    if (position >= parts.length) {
+        if (callback) {
+            return callback();
+        } else {
+            return true;
+        }
     }
-    return mkdirRecursive(pathParts.slice(0, -1).join('/'), mode, function(err) {
-      if (err && err.errno !== process.EEXIST) {
-        return callback(err);
-      }
-      fs.mkdirSync(dir, mode);
-      return callback();
+
+    var directory = parts.slice(0, position + 1).join('/');
+    fs.stat(directory, function(err) {
+        if (err === null) {
+            mkdirRecursive(path, mode, callback, position + 1);
+        } else {
+            fs.mkdir(directory, mode, function (err) {
+                if (err) {
+                    if (callback) {
+                        return callback(err);
+                    } else {
+                        throw err;
+                    }
+                } else {
+                    mkdirRecursive(path, mode, callback, position + 1);
+                }
+            });
+        }
     });
   };
 


### PR DESCRIPTION
when running in windows on production, I get the following error:

```
Express server listening on port 3000
RangeError: C:\dumps\misc\my-node-playground\express\connect-assets\views\index.
ejs:10
    8|     <h1><%= title %></h1>
    9|     <p>Welcome to <%= title %></p>
 >> 10|     <%- js('app') %>
    11|   </body>
    12| </html>

Maximum call stack size exceeded
GET / 500 442ms
```

I have to hit refresh again. and then it works.

I have updated the `mkdirRecursive` method based on http://unfoldingtheweb.com/2010/12/15/recursive-directory-nodejs/ which works correctly in windows. 
