### PR TITLE
fix mkdirRecursive for windows

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -557,7 +557,7 @@
 
   mkdirRecursive = function(dir, mode, callback) {
     var pathParts;
-    pathParts = path.normalize(dir).split('/');
+    pathParts = path.normalize(dir).replace(/\\/g,'/').split('/');
     if (path.existsSync(dir)) {
       return callback(null);
     }


### PR DESCRIPTION
converts `C:\dumps\misc\my-node-playground\express\connect-assets\views\index` to `C:/dumps/misc/my-node-playground/express/connect-assets/views/index` so that `mkdirRecursive` works correctly in windows.

more info on #103
