### PR TITLE
correctly set filename in windows for javascript

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -377,7 +377,7 @@
               _results = [];
               for (_j = 0, _len1 = chain.length; _j < _len1; _j++) {
                 _ref1 = chain[_j], filename = _ref1.filename, js = _ref1.js;
-                filename = stripExt(filename) + '.js';
+                filename = stripExt(filename).replace(/\\/g,'/') + '.js';
                 this.cache.set(filename, js);
                 _results.push("/" + filename);
               }


### PR DESCRIPTION
due to path style, routes are rendered incorrectly in windows except the first file in this case `/js/app.js`. `<%- js('app') %>`

``` hml
<script src='/js\jquery.js'></script>
<script src='/templates\a1.js'></script>
<script src='/templates\a2.js'></script>
<script src='/templates\b\c.js'></script>
<script src='/js/app.js'></script>
```

This also leads to 404 not found responses for all except `/js/app.js` as they are invalid routes.

This patch replaces `\` with `/` so the scripts and routes are registered correctly.

``` html
<script src='/js/jquery.js'></script>
<script src='/templates/a1.js'></script>
<script src='/templates/a2.js'></script>
<script src='/templates/b/c.js'></script>
<script src='/js/app.js'></script>
```
