### PR TITLE
Add support for script loading attributes

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -120,8 +120,9 @@
         return "<link rel='stylesheet' href='" + route + "'>";
       };
       context.css.root = 'css';
-      context.js = function(route) {
-        var p, r, routes;
+      context.js = function(route, routeOptions) {
+        var loadingKeyword, p, r, routes;
+        loadingKeyword = '';
         route = expandRoute(route, '.js', context.js.root);
         if (route.match(REMOTE_PATH)) {
           routes = [route];
@@ -142,12 +143,20 @@
         if (_this.options.pathsOnly) {
           return routes;
         }
+        if ((routeOptions != null) && _this.options.build) {
+          if (routeOptions.async != null) {
+            loadingKeyword = 'async ';
+          }
+          if (routeOptions.defer != null) {
+            loadingKeyword = 'defer ';
+          }
+        }
         return ((function() {
           var _i, _len, _results;
           _results = [];
           for (_i = 0, _len = routes.length; _i < _len; _i++) {
             r = routes[_i];
-            _results.push("<script src='" + r + "'></script>");
+            _results.push("<script " + loadingKeyword + "src='" + r + "'></script>");
           }
           return _results;
         })()).join('\n');

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -71,7 +71,8 @@ class ConnectAssets
       "<link rel='stylesheet' href='#{route}'>"
     context.css.root = 'css'
 
-    context.js = (route) =>
+    context.js = (route, routeOptions) =>
+      loadingKeyword = ''
       route = expandRoute route, '.js', context.js.root
       if route.match REMOTE_PATH
         routes = [route]
@@ -81,7 +82,11 @@ class ConnectAssets
         routes = (@options.servePath + p for p in @compileJS route)
 
       return routes if @options.pathsOnly
-      ("<script src='#{r}'></script>" for r in routes).join '\n'
+      if routeOptions? and @options.build
+        loadingKeyword = 'async ' if routeOptions.async?
+        loadingKeyword = 'defer ' if routeOptions.defer?
+
+      ("<script #{loadingKeyword}src='#{r}'></script>" for r in routes).join '\n'
     context.js.root = 'js'
 
     context.img = (route) =>


### PR DESCRIPTION
Add support for both the async and defer attributes of the script-tag to
control how the scripts are loaded in the browser. This adds additional
options to the jade-helper like:

!= js('myApplication', {async: true})

and

!= js('myApplication', {defer: true})

It only affects production mode—for testing and development the options
are ignored and not rendered.
