### PR TITLE
Bumping Snockets Version to support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "connect-file-cache": "0.2.4",
     "mime": "1.2.2",
-    "snockets": "git://github.com/stefankutko/snockets.git",
+    "snockets": "1.3.7",
     "underscore": "1.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Snockets 1.3.7 was patched to work with Windows systems, however connect-assets never updated the dependency.  This merge fixes that issue.
