### PR TITLE
path.normalize incompatible in windows

### DIFF
--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -352,6 +352,7 @@ timeEq = (date1, date2) ->
   date1? and date2? and date1.getTime() is date2.getTime()
 
 mkdirRecursive = (dir, mode, callback) ->
+  dir.replace /\\/g, '/'
   pathParts = path.normalize(dir).split '/'
   if fs.existsSync dir
     return callback null


### PR DESCRIPTION
this fix revers back the unintended '\' characters normalized by path.normalize()
which cause infinite recursive call to mkdirRecursive() when "build" option set to true

err msg: "RangeError: Maximum call stack size exceeded"
