### PR TITLE
Add 'includePath' option to pass to less 

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -67,6 +67,9 @@
       options.pathsOnly = false;
     }
     jsCompilers = _.extend(jsCompilers, options.jsCompilers || {});
+    if (options.includePath != null) {
+      cssCompilers.less.optionsMap.paths = options.includePath;
+    }
     connectAssets = module.exports.instance = new ConnectAssets(options);
     connectAssets.createHelpers(options);
     return connectAssets.cache.middleware;

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -29,6 +29,8 @@ module.exports = exports = (options = {}) ->
   options.pathsOnly ?= false
   jsCompilers = _.extend jsCompilers, options.jsCompilers || {}
 
+  cssCompilers.less.optionsMap.paths = options.includePath if options.includePath?
+
   connectAssets = module.exports.instance = new ConnectAssets options
   connectAssets.createHelpers options
   connectAssets.cache.middleware


### PR DESCRIPTION
Allows the user to add additional libraries
to the less include path. This is useful when
you want to keep the distribution of something
like Twitter Bootstrap in its own directory,
perhaps under node_modules.
