### PR TITLE
Don't try and resolve paths for base64 encoded images and files.

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -228,10 +228,12 @@
       var resolvedPath;
       resolvedPath = path + "";
       resolvedPath = resolvedPath.replace(/url\(|'|"|\)/g, '');
-      try {
-        resolvedPath = this.options.helperContext.img(resolvedPath);
-      } catch (e) {
-        console.error("Can't resolve image path: " + resolvedPath);
+      if (!/^data\:(image|font).*/.test(resolvedPath)) {
+        try {
+          resolvedPath = this.options.helperContext.img(resolvedPath);
+        } catch (e) {
+          console.error("Can't resolve image path: " + resolvedPath);
+        }
       }
       return "url('" + resolvedPath + "')";
     };

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -139,10 +139,11 @@ class ConnectAssets
   resolveImgPath: (path) ->
     resolvedPath = path + ""
     resolvedPath = resolvedPath.replace /url\(|'|"|\)/g, ''
-    try
-      resolvedPath = @options.helperContext.img resolvedPath
-    catch e
-      console.error "Can't resolve image path: #{resolvedPath}"
+    unless /^data\:(image|font).*/.test resolvedPath
+      try
+        resolvedPath = @options.helperContext.img resolvedPath
+      catch e
+        console.error "Can't resolve image path: #{resolvedPath}"
     return "url('#{resolvedPath}')"
 
   fixCSSImagePaths: (css) ->


### PR DESCRIPTION
I have a CSS file which contains a base64 encoded image inlined via Data URL. Connect-assets currently warns me with the following error:

```
Can't resolve image path: data:font/svg;charset=utf-8;base64,PD94
bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/Pgo8IURPQ1
RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8v
**snip**
RU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL
0RURC9zdmcxMS5kdGQiID4KPHN2ZyB4bWxucz0iaHR0cDovL3d3
dy53My5vcmcvMjAwMC9zdmciPgo8bWV0YWRhdGE+ClRoaX==
```

This pull request checks to see if the image is a Data URL and if it is, does not try and resolve the path.
