### PR TITLE
Override stylus-url() to work with assets/images.

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -420,7 +420,7 @@
     styl: {
       optionsMap: {},
       compileSync: function(sourcePath, source) {
-        var callback, options, result, _base, _ref;
+        var callback, imagesPath, options, result, _base, _ref;
         result = '';
         callback = function(err, js) {
           if (err) {
@@ -459,7 +459,10 @@
         options = (_ref = (_base = this.optionsMap)[sourcePath]) != null ? _ref : _base[sourcePath] = {
           filename: sourcePath
         };
-        libs.stylus(source, options).use(libs.bootstrap()).use(libs.nib()).use(libs.bootstrap()).set('compress', this.compress).set('include css', true).render(callback);
+        imagesPath = path.resolve(path.dirname(sourcePath), '..', 'images');
+        libs.stylus(source, options).use(libs.bootstrap()).use(libs.nib()).use(libs.bootstrap()).set('compress', this.compress).set('include css', true).define('url', libs.stylus.url({
+          paths: [imagesPath]
+        })).render(callback);
         return result;
       }
     },

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -262,12 +262,14 @@ exports.cssCompilers = cssCompilers =
       libs.bootstrap or= try require 'bootstrap-stylus' catch e then (-> ->)
       options = @optionsMap[sourcePath] ?=
         filename: sourcePath
+      imagesPath = path.resolve (path.dirname sourcePath), '..', 'images'
       libs.stylus(source, options)
           .use(libs.bootstrap())
           .use(libs.nib())
           .use(libs.bootstrap())
           .set('compress', @compress)
           .set('include css', true)
+          .define('url', (libs.stylus.url {paths:[imagesPath]}))
           .render callback
       result
 


### PR DESCRIPTION
Override the url() function in the stylus file with one provided by
stylus itself that knows about the assets structure (assets/images)
and inlines small images.
