### PR TITLE
Proper path handling for windows environments

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -566,11 +566,11 @@
 
   mkdirRecursive = function(dir, mode, callback) {
     var pathParts;
-    pathParts = path.normalize(dir).split('/');
+    pathParts = path.normalize(dir).split(path.sep);
     if (fs.existsSync(dir)) {
       return callback(null);
     }
-    return mkdirRecursive(pathParts.slice(0, -1).join('/'), mode, function(err) {
+    return mkdirRecursive(pathParts.slice(0, -1).join(path.sep), mode, function(err) {
       if (err && err.errno !== process.EEXIST) {
         return callback(err);
       }

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -352,11 +352,11 @@ timeEq = (date1, date2) ->
   date1? and date2? and date1.getTime() is date2.getTime()
 
 mkdirRecursive = (dir, mode, callback) ->
-  pathParts = path.normalize(dir).split '/'
+  pathParts = path.normalize(dir).split path.sep
   if fs.existsSync dir
     return callback null
 
-  mkdirRecursive pathParts.slice(0,-1).join('/'), mode, (err) ->
+  mkdirRecursive pathParts.slice(0,-1).join(path.sep), mode, (err) ->
     return callback err if err and err.errno isnt process.EEXIST
     fs.mkdirSync dir, mode
     callback()


### PR DESCRIPTION
This is a better fix for issue #104.

>    RangeError: ...
>    Maximum call stack size exceeded

I use the `path.sep` utility so that splitting the file path in `mkdirRecursive` will work in any environment.
