### PR TITLE
Resolve logical error checking mtimes on cached CSS from Stylus.

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -244,7 +244,7 @@
     };
 
     ConnectAssets.prototype.compileCSS = function(route) {
-      var alreadyCached, buildPath, cacheFlags, css, data, ext, filename, mtime, source, sourcePath, startTime, stats, _i, _len, _ref, _ref1, _ref2, _ref3;
+      var alreadyCached, buildPath, cacheFlags, css, data, ext, filename, mtime, source, sourcePath, startTime, stats, _i, _len, _ref, _ref1, _ref2, _ref3, _ref4;
       if (!this.options.detectChanges && this.cachedRoutePaths[route]) {
         return this.cachedRoutePaths[route];
       }
@@ -271,25 +271,29 @@
             }
           } else {
             if (timeEq(stats.mtime, (_ref2 = this.cssSourceFiles[sourcePath]) != null ? _ref2.mtime : void 0)) {
-              source = this.cssSourceFiles[sourcePath].data.toString('utf8');
-            } else {
-              data = fs.readFileSync(this.absPath(sourcePath));
-              this.cssSourceFiles[sourcePath] = {
-                data: data,
-                mtime: stats.mtime
-              };
-              source = data.toString('utf8');
-            }
-            startTime = new Date;
-            css = cssCompilers[ext].compileSync(this.absPath(sourcePath), source);
-            if (css === ((_ref3 = this.compiledCss[sourcePath]) != null ? _ref3.data.toString('utf8') : void 0)) {
               alreadyCached = true;
             } else {
-              mtime = new Date;
-              this.compiledCss[sourcePath] = {
-                data: new Buffer(css),
-                mtime: mtime
-              };
+              if ((_ref3 = this.cssSourceFiles[sourcePath]) != null ? _ref3.mtime : void 0) {
+                source = this.cssSourceFiles[sourcePath].data.toString('utf8');
+              } else {
+                data = fs.readFileSync(this.absPath(sourcePath));
+                this.cssSourceFiles[sourcePath] = {
+                  data: data,
+                  mtime: stats.mtime
+                };
+                source = data.toString('utf8');
+              }
+              startTime = new Date;
+              css = cssCompilers[ext].compileSync(this.absPath(sourcePath), source);
+              if (css === ((_ref4 = this.compiledCss[sourcePath]) != null ? _ref4.data.toString('utf8') : void 0)) {
+                alreadyCached = true;
+              } else {
+                mtime = new Date;
+                this.compiledCss[sourcePath] = {
+                  data: new Buffer(css),
+                  mtime: mtime
+                };
+              }
             }
           }
           if (alreadyCached && this.options.build) {

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -168,18 +168,21 @@ class ConnectAssets
             css = @fixCSSImagePaths css
         else
           if timeEq stats.mtime, @cssSourceFiles[sourcePath]?.mtime
-            source = @cssSourceFiles[sourcePath].data.toString 'utf8'
-          else
-            data = fs.readFileSync @absPath(sourcePath)
-            @cssSourceFiles[sourcePath] = {data, mtime: stats.mtime}
-            source = data.toString 'utf8'
-          startTime = new Date
-          css = cssCompilers[ext].compileSync @absPath(sourcePath), source
-          if css is @compiledCss[sourcePath]?.data.toString 'utf8'
             alreadyCached = true
           else
-            mtime = new Date
-            @compiledCss[sourcePath] = {data: new Buffer(css), mtime}
+            if @cssSourceFiles[sourcePath]?.mtime
+              source = @cssSourceFiles[sourcePath].data.toString 'utf8'
+            else
+              data = fs.readFileSync @absPath(sourcePath)
+              @cssSourceFiles[sourcePath] = {data, mtime: stats.mtime}
+              source = data.toString 'utf8'
+            startTime = new Date
+            css = cssCompilers[ext].compileSync @absPath(sourcePath), source
+            if css is @compiledCss[sourcePath]?.data.toString 'utf8'
+              alreadyCached = true
+            else
+              mtime = new Date
+              @compiledCss[sourcePath] = {data: new Buffer(css), mtime}
 
         if alreadyCached and @options.build
           filename = @buildFilenames[sourcePath]


### PR DESCRIPTION
mtime based caching on stylus templates was broken - this is a fix we have in production
