### PR TITLE
Fix stringified "[object Object]" less stack-trace

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -513,9 +513,16 @@
           if (err) {
             throw err;
           }
-          return result = tree.toCSS({
-            compress: compress
-          });
+          try {
+            result = tree.toCSS({
+              compress: compress
+            });
+          } catch (e) {
+            err = new Error(e.message);
+            err.stack = "" + e.message + "\n\tat " + e.filename + ":" + e.line + ":" + e.column;
+            throw err;
+          }
+          return result;
         };
         new libs.less.Parser(options).parse(source, callback);
         return result;

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -319,7 +319,14 @@ exports.cssCompilers = cssCompilers =
 
       callback = (err, tree) ->
         throw err if err
-        result = tree.toCSS({compress: compress})
+        # ## Catch and fix non-usefull stringified "[object Object]" less error message
+        try
+          result = tree.toCSS({compress: compress})
+        catch e
+          err = new Error e.message
+          err.stack = """#{e.message}\n\tat #{e.filename}:#{e.line}:#{e.column}"""
+          throw err
+        result
 
       new libs.less.Parser(options).parse(source, callback)
       result


### PR DESCRIPTION
Hi Trevor...

There are some cases when connect-assets doesn't show helpful stack traces, but instead shows "[object Object]" stringified messages.

For example:

``` less
.my-class {
   .non-existing-class;
}
```

This patch fixes it and shows a more helpful trace ( exact file  and line where the problem is ).
