### PR TITLE
A smarter default for detectChanges

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -58,7 +58,7 @@
       options.buildsExpire = false;
     }
     if ((_ref9 = options.detectChanges) == null) {
-      options.detectChanges = true;
+      options.detectChanges = process.env.NODE_ENV !== 'production';
     }
     if ((_ref10 = options.minifyBuilds) == null) {
       options.minifyBuilds = true;

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -24,7 +24,7 @@ module.exports = exports = (options = {}) ->
   options.buildDir ?= 'builtAssets'
   options.buildFilenamer ?= md5Filenamer
   options.buildsExpire ?= false
-  options.detectChanges ?= true
+  options.detectChanges ?= process.env.NODE_ENV isnt 'production'
   options.minifyBuilds ?= true
   options.pathsOnly ?= false
   jsCompilers = _.extend jsCompilers, options.jsCompilers || {}


### PR DESCRIPTION
This is a pull request to fix the now-closed #156.

Because connect-assets does a _serial synchronous_ directory scan, not
setting "detectChanges" correctly can ruin performance in production.

It can also make your test suite very slow, but correcting the default for production is the important thing.

Note that I was not able to check if this broke the test suite, since
the test suite does not run for me.
