### PR TITLE
Add `stylusExtends` option for support Stylus Javascript API

### DIFF
--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -31,6 +31,8 @@ module.exports = exports = (options = {}) ->
   options.detectChanges ?= process.env.NODE_ENV isnt 'production'
   options.minifyBuilds ?= true
   options.pathsOnly ?= false
+  libs.stylusExtends = options.stylusExtends ?= () => {};
+  
   jsCompilers = extend jsCompilers, options.jsCompilers || {}
 
   connectAssets = module.exports.instance = new ConnectAssets options
@@ -270,6 +272,7 @@ exports.cssCompilers = cssCompilers =
           .use(libs.bootstrap())
           .use(libs.nib())
           .use(libs.bootstrap())
+          .use(libs.stylusExtends)
           .set('compress', @compress)
           .set('include css', true)
           .render callback


### PR DESCRIPTION
It is about using [Stylus Javascript API](http://learnboost.github.com/stylus/docs/js.html) with connect-assets in the following style:

```
app.use(connectAssets({
    src: assetsSrc,    
    buildDir: '/html/',    
    stylusExtends: stylusExtendExampleLib
  })) 
```

For example, I have the function `stylusExtendExampleLib` with method `importRemote`, which allow remote including *.styl files into each others. 

```
var stylusExtendExampleLib = function(style){  
  style.define('importRemote', function(remoteFile){      
    var context = this;
    downloadStyl(remoteFile.val, function(toImport) {
      var body,
      block = context.currentBlock,      
      node = new stylus.nodes.String(toImport),
      expr = new stylus.nodes.Expression();
      expr.push(node);    
      body = context.visitImport(new stylus.nodes.Import(expr));  
      context.mixin(body.nodes, block);  
      style.define('importRemote', body.Nodes);   
    });

  });
};
```

(where `downloadStyl` simply is a async function `(filename, callback)' which download file from common repository if needed). 

I'm a newbie in javascript and especcially in coffeescript (actually, we use compiled version of `connect-assets` in production with many fixes), and I will be grateful for any corrections of these 2 lines of code.
