### PR TITLE
Image assets are not cache busted by the MD5 hash

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -215,7 +215,7 @@
         } else if (alreadyCached) {
           return "/" + route;
         } else if (this.options.build) {
-          filename = this.options.buildFilenamer(route, getExt(route));
+          filename = this.options.buildFilenamer(route, img);
           this.buildFilenames[sourcePath] = filename;
           cacheFlags = {
             expires: this.options.buildsExpire,

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -126,7 +126,7 @@ class ConnectAssets
       else if alreadyCached
         return "/#{route}"
       else if @options.build
-        filename = @options.buildFilenamer(route, getExt route)
+        filename = @options.buildFilenamer(route, img)
         @buildFilenames[sourcePath] = filename
         cacheFlags = {expires: @options.buildsExpire, mtime}
         @cache.set filename, img, cacheFlags

--- a/test/CdnIntegration.coffee
+++ b/test/CdnIntegration.coffee
@@ -27,7 +27,7 @@ exports['If options.servePath exists, other css URLs are still allowed'] = (test
   test.done()
 
 exports['servePath prepended to img paths on production'] = (test) ->
-  imgTag = "http://mycdn.com/img/foobar-d41d8cd98f00b204e9800998ecf8427e.png"
+  imgTag = "http://mycdn.com/img/foobar-25c2e8559281a2cd7503300442862885.png"
   test.equals img('foobar.png'), imgTag
   test.done()
 

--- a/test/ProductionIntegration.coffee
+++ b/test/ProductionIntegration.coffee
@@ -7,9 +7,9 @@ app.use assets buildDir: false  # disable saving built assets to file
 app.listen 3589
 
 exports['Far-future expires and MD5 hash strings are used for images'] = (test) ->
-  imgTag = "/img/foobar-d41d8cd98f00b204e9800998ecf8427e.png"
+  imgTag = "/img/foobar-25c2e8559281a2cd7503300442862885.png"
   test.equals img('foobar.png'), imgTag
-  request 'http://localhost:3589/img/foobar-d41d8cd98f00b204e9800998ecf8427e.png', (err, res, body) ->
+  request 'http://localhost:3589/img/foobar-25c2e8559281a2cd7503300442862885.png', (err, res, body) ->
     throw err if err
     test.equals res.headers['content-type'], 'image/png'
     test.equals res.headers['expires'], 'Wed, 01 Feb 2034 12:34:56 GMT'


### PR DESCRIPTION
Image asset content is not sent to the MD5 hash and as a result all image MD5 hashes are the same. The behaviour I was expecting is that when the image content changes so does the hash. I updated the code to behave in this way.
