### PR TITLE
Add new option 'gracefulMissingImages' which doesnt throw error for missing images

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -33,7 +33,7 @@
   };
 
   module.exports = exports = function(options) {
-    var connectAssets, _base, _base1, _ref, _ref1, _ref10, _ref11, _ref12, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9,
+    var connectAssets, _base, _base1, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9,
       _this = this;
     if (options == null) {
       options = {};
@@ -79,7 +79,10 @@
     if ((_ref11 = options.pathsOnly) == null) {
       options.pathsOnly = false;
     }
-    libs.stylusExtends = (_ref12 = options.stylusExtends) != null ? _ref12 : options.stylusExtends = function() {
+    if ((_ref12 = options.gracefulMissingImages) == null) {
+      options.gracefulMissingImages = false;
+    }
+    libs.stylusExtends = (_ref13 = options.stylusExtends) != null ? _ref13 : options.stylusExtends = function() {
       return {};
     };
     jsCompilers = extend(jsCompilers, options.jsCompilers || {});
@@ -239,7 +242,11 @@
         '';
 
       }
-      throw new Error("No file found for route " + route);
+      if (this.options.gracefulMissingImages) {
+        return "/__missing-image";
+      } else {
+        throw new Error("No file found for route " + route);
+      }
     };
 
     ConnectAssets.prototype.resolveImgPath = function(path) {

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -31,8 +31,9 @@ module.exports = exports = (options = {}) ->
   options.detectChanges ?= process.env.NODE_ENV isnt 'production'
   options.minifyBuilds ?= true
   options.pathsOnly ?= false
+  options.gracefulMissingImages ?= false
   libs.stylusExtends = options.stylusExtends ?= () => {};
-  
+
   jsCompilers = extend jsCompilers, options.jsCompilers || {}
 
   connectAssets = module.exports.instance = new ConnectAssets options
@@ -140,7 +141,10 @@ class ConnectAssets
         return @cachedRoutePaths[route] = "/#{route}"
     catch e
       ''
-    throw new Error("No file found for route #{route}")
+    if @options.gracefulMissingImages
+      return "/__missing-image"
+    else
+      throw new Error("No file found for route #{route}")
 
   resolveImgPath: (path) ->
     resolvedPath = path + ""


### PR DESCRIPTION
In my app I have many images loaded from the database, and I am using the connect-assets img helper to render the correct assets path to the view 

Currently, if someone would accidentally remove an image, my whole app would crash if someone visited that page, which doesn't seem very robust:

```
Error: No file found for route foo.jpg
```

I don't want to guard against this by checking that each image actually exists as this will create a whole lot of overhead; much better rather that connect-assets can gracefully handle missing images.

My solution is that if you set gracefulMissingImages to true, connect-assets will simply return path '/__missing-image'. The image will be broken (unless you add a route for that path), but at least the application will not crash. 

You could then add a handler for example in express that could notify you of missing images if you wanted... and perhaps render a nice placeholder image. 
