### PR TITLE
Support Less 1.4.0

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -488,41 +488,10 @@
         paths: [],
         color: true
       },
-      patchLess: function(less) {
-        less.Parser.importer = function(file, paths, callback) {
-          var data, i, pathname;
-          paths.unshift(".");
-          i = 0;
-          while (i < paths.length) {
-            try {
-              pathname = path.join(paths[i], file);
-              fs.statSync(pathname);
-              break;
-            } catch (e) {
-              pathname = null;
-            }
-            i++;
-          }
-          if (!pathname) {
-            throw new Error("File " + file + " not found");
-          }
-          data = fs.readFileSync(pathname, 'utf-8');
-          return new less.Parser({
-            paths: [path.dirname(pathname)].concat(paths),
-            filename: pathname
-          }).parse(data, function(e, root) {
-            if (e) {
-              less.writeError(e);
-            }
-            return callback(e, root);
-          });
-        };
-        return less;
-      },
       compileSync: function(sourcePath, source) {
-        var callback, compress, options, result, _ref;
+        var callback, compress, env, options, result, _ref;
         result = "";
-        libs.less || (libs.less = this.patchLess(require('less')));
+        libs.less || (libs.less = require('less'));
         options = this.optionsMap;
         options.filename = sourcePath;
         options.paths = [path.dirname(sourcePath)].concat(options.paths);
@@ -535,7 +504,9 @@
             compress: compress
           });
         };
-        new libs.less.Parser(options).parse(source, callback);
+        env = new libs.less.tree.parseEnv(options);
+        env.syncImport = true;
+        new libs.less.Parser(env).parse(source, callback);
         return result;
       }
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "stylus": "0.22.2",
     "request": "2.1.1",
     "watchit": "0.0.4",
-    "less": "1.3.0",
+    "less": "1.4.0",
     "docco": "~0.4.0"
   },
   "scripts": {

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -32,7 +32,7 @@ module.exports = exports = (options = {}) ->
   options.minifyBuilds ?= true
   options.pathsOnly ?= false
   libs.stylusExtends = options.stylusExtends ?= () => {};
-  
+
   jsCompilers = extend jsCompilers, options.jsCompilers || {}
 
   connectAssets = module.exports.instance = new ConnectAssets options
@@ -285,40 +285,9 @@ exports.cssCompilers = cssCompilers =
       paths: []
       color: true
 
-    patchLess: (less) ->
-      # Monkey patch importer of LESS to load files synchronously
-      less.Parser.importer = (file, paths, callback) ->
-        paths.unshift "."
-
-        i = 0
-        while i < paths.length
-          try
-            pathname = path.join(paths[i], file)
-            fs.statSync(pathname)
-            break
-          catch e
-            pathname = null
-
-          i++
-
-        if not pathname
-          throw new Error "File #{file} not found"
-
-        data = fs.readFileSync(pathname, 'utf-8')
-        new(less.Parser)(
-          paths: [path.dirname(pathname)].concat(paths)
-          filename: pathname
-        ).parse(data, (e, root) ->
-          if (e)
-            less.writeError(e)
-          callback(e, root)
-        )
-
-      less
-
     compileSync: (sourcePath, source) ->
       result = ""
-      libs.less or= @patchLess (require 'less')
+      libs.less or= require 'less'
       options = @optionsMap
       options.filename = sourcePath
       options.paths = [path.dirname(sourcePath)].concat(options.paths)
@@ -327,8 +296,9 @@ exports.cssCompilers = cssCompilers =
       callback = (err, tree) ->
         throw err if err
         result = tree.toCSS({compress: compress})
-
-      new libs.less.Parser(options).parse(source, callback)
+      env = new libs.less.tree.parseEnv options
+      env.syncImport = true
+      new libs.less.Parser(env).parse(source, callback)
       result
 
 


### PR DESCRIPTION
- Use builtin Less option to import synchronously
- Don't monkeypatch Less anymore

We had to instantiate a `libs.less.tree.parseEnv` object and set syncImport to true manually on it in order to circumvent a bug in Less (https://github.com/less/less.js/issues/1389) instead of passing a simple option objects. When the bug is fixed upstream, syncImport can be set again as a property of an option object passed to the Parser constructor.
