### PR TITLE
Image assets in css files do not get an MD5 hash when they contain query strings or hashes

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -89,6 +89,7 @@
   };
 
   ConnectAssets = (function() {
+    var extractQueryAndHash, removeQueryAndHash;
 
     function ConnectAssets(options) {
       this.options = options;
@@ -242,16 +243,34 @@
       throw new Error("No file found for route " + route);
     };
 
+    extractQueryAndHash = function(path) {
+      var hash, parsedPath, query;
+      parsedPath = parse(path);
+      hash = parsedPath.hash || '';
+      query = parsedPath.query ? "?" + parsedPath.query : '';
+      return "" + query + hash;
+    };
+
+    removeQueryAndHash = function(path) {
+      var hash, parsedPath, query;
+      parsedPath = parse(path);
+      hash = parsedPath.hash || '';
+      query = parsedPath.query ? "?" + parsedPath.query : '';
+      return path.replace(hash, '').replace(query, '');
+    };
+
     ConnectAssets.prototype.resolveImgPath = function(path) {
-      var resolvedPath;
+      var queryAndHash, resolvedPath;
       resolvedPath = path + "";
       resolvedPath = resolvedPath.replace(/url\(|'|"|\)/g, '');
+      queryAndHash = extractQueryAndHash(resolvedPath);
+      resolvedPath = removeQueryAndHash(resolvedPath);
       try {
         resolvedPath = this.options.helperContext.img(resolvedPath);
       } catch (e) {
         console.error("Can't resolve image path: " + resolvedPath);
       }
-      return "url('" + resolvedPath + "')";
+      return "url('" + resolvedPath + queryAndHash + "')";
     };
 
     ConnectAssets.prototype.fixCSSImagePaths = function(css) {

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -142,14 +142,28 @@ class ConnectAssets
       ''
     throw new Error("No file found for route #{route}")
 
+  extractQueryAndHash = (path) ->
+    parsedPath = parse(path)
+    hash = parsedPath.hash || ''
+    query = if parsedPath.query then "?#{parsedPath.query}" else ''
+    "#{query}#{hash}"
+
+  removeQueryAndHash = (path) ->
+    parsedPath = parse(path)
+    hash = parsedPath.hash || ''
+    query = if parsedPath.query then "?#{parsedPath.query}" else ''
+    path.replace(hash, '').replace(query, '')
+
   resolveImgPath: (path) ->
     resolvedPath = path + ""
     resolvedPath = resolvedPath.replace /url\(|'|"|\)/g, ''
+    queryAndHash = extractQueryAndHash(resolvedPath)
+    resolvedPath = removeQueryAndHash(resolvedPath)
     try
       resolvedPath = @options.helperContext.img resolvedPath
     catch e
       console.error "Can't resolve image path: #{resolvedPath}"
-    return "url('#{resolvedPath}')"
+    return "url('#{resolvedPath}#{queryAndHash}')"
 
   fixCSSImagePaths: (css) ->
     regex = /url\([^\)]+\)/g

--- a/test/ProductionIntegration.coffee
+++ b/test/ProductionIntegration.coffee
@@ -6,6 +6,8 @@ assets = require('../lib/assets.js')
 app.use assets buildDir: false  # disable saving built assets to file
 app.listen 3589
 
+extractCssHref = (cssLink) -> cssLink.replace('<link rel="stylesheet" href="', '').replace('" />', '')
+
 exports['Far-future expires and MD5 hash strings are used for images'] = (test) ->
   imgTag = "/img/foobar-25c2e8559281a2cd7503300442862885.png"
   test.equals img('foobar.png'), imgTag
@@ -13,6 +15,34 @@ exports['Far-future expires and MD5 hash strings are used for images'] = (test) 
     throw err if err
     test.equals res.headers['content-type'], 'image/png'
     test.equals res.headers['expires'], 'Wed, 01 Feb 2034 12:34:56 GMT'
+    test.done()
+
+exports['MD5 hash strings are used for images in CSS files'] = (test) ->
+  relativeCssPath = extractCssHref css('background.css')
+  request "http://localhost:3589#{relativeCssPath}", (err, res, body) ->
+    throw err if err
+    test.equals body, '.background { background-image: url(\'/img/foobar-25c2e8559281a2cd7503300442862885.png\'); }'
+    test.done()
+
+exports['MD5 hash strings are used for images with hashes in CSS files'] = (test) ->
+  relativeCssPath = extractCssHref css('background-with-hash.css')
+  request "http://localhost:3589#{relativeCssPath}", (err, res, body) ->
+    throw err if err
+    test.equals body, '.background { background-image: url(\'/img/foobar-25c2e8559281a2cd7503300442862885.png#a-hash\'); }'
+    test.done()
+
+exports['MD5 hash strings are used for images with query strings in CSS files'] = (test) ->
+  relativeCssPath = extractCssHref css('background-with-query.css')
+  request "http://localhost:3589#{relativeCssPath}", (err, res, body) ->
+    throw err if err
+    test.equals body, '.background { background-image: url(\'/img/foobar-25c2e8559281a2cd7503300442862885.png?a=query\'); }'
+    test.done()
+
+exports['MD5 hash strings are used for images with hashes and query srings in CSS files'] = (test) ->
+  relativeCssPath = extractCssHref css('background-with-hash-and-query.css')
+  request "http://localhost:3589#{relativeCssPath}", (err, res, body) ->
+    throw err if err
+    test.equals body, '.background { background-image: url(\'/img/foobar-25c2e8559281a2cd7503300442862885.png?a=query#a-hash\'); }'
     test.done()
 
 exports['Far-future expires and MD5 hash strings are used for CSS'] = (test) ->

--- a/test/assets/css/background-with-hash-and-query.css
+++ b/test/assets/css/background-with-hash-and-query.css
@@ -1,0 +1,1 @@
+.background { background-image: url("/img/foobar.png?a=query#a-hash"); }

--- a/test/assets/css/background-with-hash.css
+++ b/test/assets/css/background-with-hash.css
@@ -1,0 +1,1 @@
+.background { background-image: url("/img/foobar.png#a-hash"); }

--- a/test/assets/css/background-with-query.css
+++ b/test/assets/css/background-with-query.css
@@ -1,0 +1,1 @@
+.background { background-image: url("/img/foobar.png?a=query"); }

--- a/test/assets/css/background.css
+++ b/test/assets/css/background.css
@@ -1,3 +1,1 @@
-div .background {
-  background-image: url(/img/foobar.png);
-}
+.background { background-image: url("/img/foobar.png"); }


### PR DESCRIPTION
I have encountered a bug in connect-assets where image assets (or in my case font assets) do not get an MD5 hash when they contain a query string or hash. I have fixed this bug. I believe I have captured all the cases in the tests, but please have a look over and see if you can think of any other edge cases we should look out for.

FYI the production CSS that I am having the issue on is this:

``` css
@font-face {
  font-family: 'SourceSansProRegular';
  src: url('/content/fonts/SourceSansPro-Regular-webfont.eot');
  src: url('/content/fonts/SourceSansPro-Regular-webfont.eot?#iefix') format('embedded-opentype'), url('/content/fonts/SourceSansPro-Regular-webfont.woff') format('woff'), url('/content/fonts/SourceSansPro-Regular-webfont.ttf') format('truetype'),  url('/content/fonts/SourceSansPro-Regular-webfont.svg#SourceSansProRegular') format('svg');
  font-weight: normal;
  font-style: normal;
}
```

Which gets generated in production as this (resulting in 404 not found on the server):

``` css
@font-face {
font-family:'SourceSansProRegular';
src:url(/content/fonts/SourceSansPro-Regular-webfont-e9e65e67001fc8ce81ab9345c676a085.eot);
src:url(/content/fonts/SourceSansPro-Regular-webfont.eot?#iefix) format("embedded-opentype)","url(/content/fonts/SourceSansPro-Regular-webfont-608b244358954d2f861c952fa8927d0c.woff") format("woff)","url(/content/fonts/SourceSansPro-Regular-webfont-2bd8bac925bf9e744adfc97019035b8c.ttf") format("truetype)","url(/content/fonts/SourceSansPro-Regular-webfont.svg#SourceSansProRegular") format("svg");
font-weight:400;
font-style:normal
}
```

But I believe should be generated as this:

``` css
@font-face {
font-family:'SourceSansProRegular';
src:url(/content/fonts/SourceSansPro-Regular-webfont-e9e65e67001fc8ce81ab9345c676a085.eot);
src:url(/content/fonts/SourceSansPro-Regular-webfont-e9e65e67001fc8ce81ab9345c676a085.eot#iefix) format("embedded-opentype)","url(/content/fonts/SourceSansPro-Regular-webfont-608b244358954d2f861c952fa8927d0c.woff") format("woff)","url(/content/fonts/SourceSansPro-Regular-webfont-2bd8bac925bf9e744adfc97019035b8c.ttf") format("truetype)","url(/content/fonts/SourceSansPro-Regular-webfont-a2454401f56e0619a2e270dfa24fdb5d.svg#SourceSansProRegular") format("svg");
font-weight:400;
font-style:normal
}
```
