### PR TITLE
add support for media attribute as a param for css()

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -129,14 +129,20 @@
         return shortRoute;
       };
       context.css = function(route, media) {
+        var link;
+        link = '';
         route = expandRoute(route, '.css', context.css.root);
         if (!route.match(REMOTE_PATH)) {
           route = _this.options.servePath + _this.compileCSS(route);
         }
+        link = ['<link rel="stylesheet" href="', route, '" />'].join('');
         if (_this.options.pathsOnly) {
-          return route;
+          link = route;
         }
-        return ['<link rel="stylesheet" media="', media || "screen", '" href="', route, '" />'].join('');
+        if (media) {
+          link = ['<link rel="stylesheet" media="', media, '" href="', route, '" />'].join('');
+        }
+        return link;
       };
       context.css.root = 'css';
       context.js = function(route, routeOptions) {

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -70,11 +70,15 @@ class ConnectAssets
       shortRoute
 
     context.css = (route, media) =>
+      link = ''
       route = expandRoute route, '.css', context.css.root
       unless route.match REMOTE_PATH
         route = @options.servePath + @compileCSS route
-      return route if @options.pathsOnly
-      ['<link rel="stylesheet" media="', media || "screen", '" href="', route,'" />'].join('')
+      link = ['<link rel="stylesheet" href="', route,'" />'].join('')
+      link = route if @options.pathsOnly 
+      link = ['<link rel="stylesheet" media="', media, '" href="', route,'" />'].join('') if media
+      return link
+
     context.css.root = 'css'
 
     context.js = (route, routeOptions) =>


### PR DESCRIPTION
I added support for specifying the "media" attribute as a parameter to context.css().
