### PR TITLE
Wrap asseturl in literal node to support newer versions of stylus.

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -509,7 +509,7 @@
           filename: sourcePath
         };
         libs.stylus(source, options).use(libs.bootstrap()).use(libs.nib()).use(libs.bootstrap()).use(libs.stylusExtends).define('asseturl', function(url) {
-          return "url(" + (helperContext.img(url.val)) + ")";
+          return new libs.stylus.nodes.Literal("url(" + (helperContext.img(url.val)) + ")");
         }).set('compress', this.compress).set('include css', true).render(callback);
         return result;
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "nib": "0.2.0",
     "bootstrap-stylus": "0.2.0",
     "nodeunit": "0.7.4",
-    "stylus": "0.22.2",
+    "stylus": "0.39.4",
     "request": "2.1.1",
     "watchit": "0.0.4",
     "less": "1.4.0",

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -300,7 +300,7 @@ exports.cssCompilers = cssCompilers =
           .use(libs.nib())
           .use(libs.bootstrap())
           .use(libs.stylusExtends)
-          .define('asseturl', (url) -> "url(#{helperContext.img(url.val)})")
+          .define('asseturl', (url) -> new libs.stylus.nodes.Literal("url(#{helperContext.img(url.val)})") )
           .set('compress', @compress)
           .set('include css', true)
           .render callback


### PR DESCRIPTION
It appears that Stylus's compiler is now wrapping strings returned from custom functions in single quotes. Wrapping the string in a Stylus Literal node corrects this problem. I've tested that this works in Stylus 0.22.2 and in 0.39.4. I've updated the stylus revision to ensure the tests run against modern code.
