### PR TITLE
Fix mtime usage in compileCSS

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -310,22 +310,22 @@
         sourcePath = stripExt(route) + ("." + ext);
         try {
           stats = fs.statSync(this.absPath(sourcePath));
+          mtime = stats.mtime;
           if (ext === 'css') {
             if (timeEq(mtime, (_ref1 = this.cache.map[route]) != null ? _ref1.mtime : void 0)) {
               alreadyCached = true;
             } else {
-              mtime = stats.mtime;
               css = (fs.readFileSync(this.absPath(sourcePath))).toString('utf8');
               css = this.fixCSSImagePaths(css);
             }
           } else {
-            if (timeEq(stats.mtime, (_ref2 = this.cssSourceFiles[sourcePath]) != null ? _ref2.mtime : void 0)) {
+            if (timeEq(mtime, (_ref2 = this.cssSourceFiles[sourcePath]) != null ? _ref2.mtime : void 0)) {
               source = this.cssSourceFiles[sourcePath].data.toString('utf8');
             } else {
               data = fs.readFileSync(this.absPath(sourcePath));
               this.cssSourceFiles[sourcePath] = {
                 data: data,
-                mtime: stats.mtime
+                mtime: mtime
               };
               source = data.toString('utf8');
             }

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -192,19 +192,19 @@ class ConnectAssets
       sourcePath = stripExt(route) + ".#{ext}"
       try
         stats = fs.statSync @absPath(sourcePath)
+        {mtime} = stats
         if ext is 'css'
           if timeEq mtime, @cache.map[route]?.mtime
             alreadyCached = true
           else
-            {mtime} = stats
             css = (fs.readFileSync @absPath(sourcePath)).toString 'utf8'
             css = @fixCSSImagePaths css
         else
-          if timeEq stats.mtime, @cssSourceFiles[sourcePath]?.mtime
+          if timeEq mtime, @cssSourceFiles[sourcePath]?.mtime
             source = @cssSourceFiles[sourcePath].data.toString 'utf8'
           else
             data = fs.readFileSync @absPath(sourcePath)
-            @cssSourceFiles[sourcePath] = {data, mtime: stats.mtime}
+            @cssSourceFiles[sourcePath] = {data, mtime}
             source = data.toString 'utf8'
           startTime = new Date
           css = cssCompilers[ext].compileSync @absPath(sourcePath), source, @options.helperContext


### PR DESCRIPTION
mainly fix the problem in the few lines below, the mtime is undefined in the first `if` statement.

``` coffee-script
        stats = fs.statSync @absPath(sourcePath)
        if ext is 'css'
          if timeEq mtime, @cache.map[route]?.mtime
            alreadyCached = true
          else
            {mtime} = stats
            css = (fs.readFileSync @absPath(sourcePath)).toString 'utf8'
            css = @fixCSSImagePaths css
```
