### PR TITLE
fix for assets not loading when using predefined manifest

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -135,7 +135,7 @@ Assets.prototype.helper = function (tagWriter, ext) {
 
     var getTag = function (asset) {
       var servePath = instance.options.servePath;
-      var path = servePath + "/" + asset.logical_path;
+      var path = servePath + "/" + (asset.logicalPath || asset.logical_path);
       var attributes = parseAttributes(options);
 
       if (!isAbsolutePath(servePath)) {


### PR DESCRIPTION
When using a predefined manifest with compile false, the assets were not generated because the issues in mapping of assets. 
