### PR TITLE
RFC: Expose Mincer module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var url = require("url");
+var mincer = require("mincer");
 var Assets = require("./lib/assets");
 
 var connectAssets = module.exports = function (options) {
@@ -73,3 +74,5 @@ var tagWriters = {
   js: function (url, attr) { return '<script src="' + url + '"' + pasteAttr(attr) + '></script>'; },
   noop: function (url) { return url; }
 };
+
+connectAssets.mincer = mincer;


### PR DESCRIPTION
Looks like connect-assets v3 is based on powerful Mincer package. It would be nice to expose it to the outside world, so that users can take advantage of that. For example, to add new engines to Mincer using `registerEngine`.
