### PR TITLE
Subresource

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -214,7 +214,7 @@
         scripts = [];
         for (_i = 0, _len = routes.length; _i < _len; _i++) {
           r = routes[_i];
-          scripts.push("<link " + (attrs.concat("src=\"" + r + "\"").join(" ")) + " />");
+          scripts.push("<link " + (attrs.concat("href=\"" + r + "\"").join(" ")) + " />");
         }
         return scripts.join("\n");
       };

--- a/src/assets.coffee
+++ b/src/assets.coffee
@@ -120,7 +120,7 @@ class ConnectAssets
       [routes, attrs] = context._js(route, routeOptions)
       scripts = []
       for r in routes
-        scripts.push "<link #{attrs.concat("src=\"#{r}\"").join " "} />"
+        scripts.push "<link #{attrs.concat("href=\"#{r}\"").join " "} />"
       scripts.join "\n"
 
     context.img = (route) =>

--- a/test/AbsoluteIntegration.coffee
+++ b/test/AbsoluteIntegration.coffee
@@ -55,5 +55,5 @@ exports['JS dependencies work from absolute options.src'] = (test) ->
     app.close()
 
 exports['Single subresource file work from absolute options.src'] = (test) ->
-  test.equals sub('js-dependency'), '<link rel="subresource" src="/js/js-dependency.js" />'
+  test.equals sub('js-dependency'), '<link rel="subresource" href="/js/js-dependency.js" />'
   test.done()


### PR DESCRIPTION
This adds support for the `sub` helper which generates a link rel=subresource (http://www.chromium.org/spdy/link-headers-and-server-hint/link-rel-subresource) 

I wanted to re-use the logic of the js helper, but the only way I figured out how was to pollute the context...sorry.
