### PR TITLE
define the asset_path helper

### DIFF
--- a/bin/connect-assets
+++ b/bin/connect-assets
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 var ArgumentParser = require("argparse").ArgumentParser;
+var Assets = require("../lib/assets");
 var mincer = require("mincer");
 
 var initialize = exports.initialize = function () {
@@ -41,6 +42,13 @@ var initialize = exports.initialize = function () {
       "Defaults to 'builtAssets'.",
     metavar: "DIRECTORY",
     defaultValue: "builtAssets"
+  });
+
+  cli.addArgument(["-s", "--servePath"], {
+    help: "The virtual path in which assets will be served over HTTP. " +
+      "If hosting assets locally, supply a local path (say, \"assets\"). " +
+      "If hosting assets remotely on a CDN, supply a URL",
+    defaultValue: "assets"
   });
 
   return cli;
@@ -101,14 +109,16 @@ var compile = exports.compile = function (logger, args, callback) {
 };
 
 var _compile = exports._compile = function (args, callback) {
-  var environment = new mincer.Environment();
-  var manifest = new mincer.Manifest(environment, args.output);
+  var assets = new Assets({
+    paths: args.include,
+    compile: true,
+    compress: true,
+    buildDir: args.output,
+    servePath: args.servePath,
+    precompile: args.compile
+  });
 
-  environment.cssCompressor = "csso";
-  environment.jsCompressor = "uglify";
-
-  args.include.forEach(environment.appendPath, environment);
-  manifest.compile(args.compile, callback);
+  assets.compile(callback);
 };
 
 var flatten = function (arr) { return [].concat.apply([], arr); };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var connectAssets = module.exports = function (options) {
   var compilationError;
   var waiting = [];
 
-  // TODO: environment.registerHelper asset_path?
   options.helperContext.css = assets.helper(tagWriters.css, "css");
   options.helperContext.js = assets.helper(tagWriters.js, "js");
   options.helperContext.assetPath = assets.helper(tagWriters.noop);

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -8,6 +8,10 @@ var Assets = module.exports = function (options) {
   if (this.options.compile) {
     this.environment = new mincer.Environment();
 
+    this.environment.ContextClass.defineAssetPath(this.helper(function (url) {
+      return url;
+    }));
+
     if (this.options.compress) {
       this.environment.cssCompressor = "csso";
       this.environment.jsCompressor = "uglify";

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "blanket": "1.1.6",
     "expect.js": "0.2.0",
     "travis-cov": "0.2.5",
-    "connect": "2.8.5"
+    "connect": "2.8.5",
+    "ejs": "1.0.0"
   },
   "config": {
     "travis-cov": {

--- a/test/assets/css/asset-path-helper.css.ejs
+++ b/test/assets/css/asset-path-helper.css.ejs
@@ -1,0 +1,1 @@
+@import "<%- asset_path('asset.css') %>";

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -68,4 +68,30 @@ describe("connect-assets command-line interface", function () {
       rmrf("builtAssets", done);
     });
   });
+
+  it("compiles with asset_path helper", function (done) {
+    var argv = process.argv;
+    process.argv = "node connect-assets -i test/assets/css -c asset-path-helper.css".split(" ");
+
+    bin.execute(this.logger, function () {
+      process.argv = argv;
+
+      var css = "builtAssets/asset-path-helper-c0a0370b5301dd15cb1eafc03ba78793.css";
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import \"/assets/asset-20069ab163c070349198aa05124dcaa8.css\";");
+      rmrf("builtAssets", done);
+    });
+  });
+
+  it("compiles with asset_path helper with servePath option defined", function (done) {
+    var argv = process.argv;
+    process.argv = "node connect-assets -i test/assets/css -c asset-path-helper.css -s //cdn.example.com".split(" ");
+
+    bin.execute(this.logger, function () {
+      process.argv = argv;
+
+      var css = "builtAssets/asset-path-helper-954c8a140f34be3c86bc3f0a8c79e1ca.css";
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import \"//cdn.example.com/asset-20069ab163c070349198aa05124dcaa8.css\";");
+      rmrf("builtAssets", done);
+    });
+  });
 });

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -1,0 +1,31 @@
+var expect = require("expect.js");
+var mocha = require("mocha");
+var http = require("http");
+var fs = require("fs");
+var createServer = require("./testHelpers/createServer");
+var rmrf = require("./testHelpers/rmrf");
+
+describe("serveAsset asset_path environment helper", function () {
+
+  it("minifies css in production", function (done) {
+    var env = process.env.NODE_ENV;
+    var dir = "testBuiltAssetsFoo";
+
+    createServer.call(this, { buildDir: dir, compile: true }, function () {
+      var path = this.assetPath("asset-path-helper.css");
+      var filename = dir + "/asset-path-helper-7e2feaf5cce60b2ef010192da0f7da2b.css";
+      var url = this.host + path;
+
+      http.get(url, function (res) {
+        expect(res.statusCode).to.equal(200);
+        expect(fs.statSync(dir).isDirectory()).to.equal(true);
+        expect(fs.statSync(filename).isFile()).to.equal(true);
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-20069ab163c070349198aa05124dcaa8.css\";\n");
+
+        process.env.NODE_ENV = env;
+        rmrf(dir, done);
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
I added support for having asset_path be defined for use in templated assets.  Bootstrap 3 SASS requires it and this fixes the issue.

Also note that I modified `bin/connect-assets` to use `lib/assets.js` for compiling for consistency.
