### PR TITLE
Path error when manifest exists and compile false

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -129,7 +129,8 @@ Assets.prototype.helper = function (tagWriter, ext) {
     }
 
     if (!instance.options.compile) {
-      asset = instance.manifest.assets[path];
+      var assetTitle = instance.manifest.assets[path];
+      asset = instance.manifest.files[assetTitle];
     }
     else {
       asset = instance.environment.findAsset(path);
@@ -143,8 +144,17 @@ Assets.prototype.helper = function (tagWriter, ext) {
     }
 
     var getTag = function (asset) {
+      var logicalPath;
       var servePath = instance.options.servePath;
-      var path = servePath + "/" + asset.logicalPath;
+
+      if (!instance.options.compile) {
+        logicalPath = asset.logical_path;
+      }
+      else {
+        logicalPath = asset.logicalPath;
+      } 
+           
+      var path = servePath + "/" + logicalPath;
       var attributes = parseAttributes(options);
 
       if (!isAbsolutePath(servePath)) {


### PR DESCRIPTION
Fix path error when using servePath and existing manifest with compile
false as in https://github.com/adunkman/connect-assets/issues/270
