### PR TITLE
Fix URL parsing for URL with no protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var connectAssets = module.exports = function (options) {
   });
 
   var middleware = function (req, res, next) {
-    var path = url.parse(req.url).pathname.replace(/^\//, "");
+    var path = url.parse(req.url, false, true).pathname.replace(/^\//, "");
 
     if (path.toLowerCase().indexOf(options.localServePath.toLowerCase()) === 0) {
       var serve = function (req, res, next) {
@@ -57,8 +57,9 @@ var parseOptions = module.exports._parseOptions = function (options) {
 
   options.paths = arrayify(options.paths || options.src || [ "assets/js", "assets/css" ]);
   options.helperContext = options.helperContext || global;
-  options.servePath = (options.servePath || "assets").replace(/^\//, "").replace(/\/$/, "");
-  options.localServePath = options.localServePath || url.parse(options.servePath).pathname.replace(/^\//, "");
+  options.servePath = (options.servePath || "assets");
+  options.localServePath = options.localServePath || url.parse(options.servePath, false, true).pathname.replace(/^\//, "");
+  options.servePath = options.servePath.replace(/^\//, "").replace(/\/$/, "");
   options.precompile = arrayify(options.precompile || ["*.*"]);
   options.build = options.build != null ? options.build : isProduction;
   options.buildDir = options.buildDir != null ? options.buildDir : isDevelopment ? false : "builtAssets";

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -57,7 +57,7 @@ Assets.prototype.compile = function (callback) {
 };
 
 Assets.prototype.serveAsset = function (req, res, next) {
-  var path = url.parse(req.url).pathname.replace(/^\//, "");
+  var path = url.parse(req.url, false, true).pathname.replace(/^\//, "");
   path = path.substr(this.options.localServePath.length).replace(/^\//, "");
   path = decodeURIComponent(path);
 


### PR DESCRIPTION
Seems connect-assets could not handle //cdn.example.com/assets/ path
it has to explicitly be http://cdn.example.com/assets to be parsed
by url.parse, this may not work for pages that can be served both
by http and https.

url.parse has a slashesDenoteHost flag to allow parsing of //cdn.example.com

Change-Id: Ibb52cd148e1c646763ebc6afce587e9f89aebcd2
