### PR TITLE
By the default, we don't need to compile when 'manifest.json' already exists in the buildDir.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var parseOptions = module.exports._parseOptions = function (options) {
   options.precompile = arrayify(options.precompile || ["*.*"]);
   options.build = options.build != null ? options.build : isProduction;
   options.buildDir = options.buildDir != null ? options.buildDir : isDevelopment ? false : "builtAssets";
-  options.compile = options.compile != null ? options.compile : !exists(options.buildDir);
+  options.compile = options.compile != null ? options.compile : isDevelopment ? true : !exists(options.buildDir);
   options.compress = options.compress != null ? options.compress : isProduction;
   options.gzip = options.gzip != null ? options.gzip : false;
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var url = require("url");
 var fs = require("fs");
+var path = require("path");
 var Assets = require("./lib/assets");
 
 var connectAssets = module.exports = function (options) {
@@ -62,7 +63,7 @@ var parseOptions = module.exports._parseOptions = function (options) {
   options.precompile = arrayify(options.precompile || ["*.*"]);
   options.build = options.build != null ? options.build : isProduction;
   options.buildDir = options.buildDir != null ? options.buildDir : isDevelopment ? false : "builtAssets";
-  options.compile = options.compile != null ? options.compile : true;
+  options.compile = options.compile != null ? options.compile : !exists(options.buildDir);
   options.compress = options.compress != null ? options.compress : isProduction;
   options.gzip = options.gzip != null ? options.gzip : false;
 
@@ -71,6 +72,19 @@ var parseOptions = module.exports._parseOptions = function (options) {
   }
 
   return options;
+};
+
+var exists = function (buildDir) {
+  if (!buildDir) return false;
+  var manifest = path.join(buildDir, 'manifest.json');
+  if (!fs.existsSync(manifest)) return false;
+  var assets = JSON.parse(fs.readFileSync(manifest)).assets;
+  var keys = Object.keys(assets);
+  for (var i = 0; i < keys.length; i++) {
+    if (!fs.existsSync(path.join(buildDir, assets[keys[i]])))
+      return false;
+  }
+  return true;
 };
 
 var arrayify = module.exports._arrayify = function (target) {


### PR DESCRIPTION
By the default ( = 'compile' option is null), we don't need to compile when 'manifest.json' already exists in the buildDir.