### PR TITLE
Added an option to remove fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ buildDir      | dev: false; prod: "builtAssets" | The directory to save (and loa
 compile       | true                            | Should assets be compiled if they don’t already exist in the `buildDir`?
 compress      | dev: false; prod: true          | Should assets be minified? If enabled, requires `uglify-js` and `csso`.
 gzip          | false                           | Should assets have gzipped copies in `buildDir`?
+fingerprints  | dev: false; prod: true          | Should assets be suffixed by a fingerprints : index.js is served as index-3789dsf88fd.js
 
 ## Serving Assets from a CDN
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ var parseOptions = module.exports._parseOptions = function (options) {
   options.compile = options.compile != null ? options.compile : true;
   options.compress = options.compress != null ? options.compress : isProduction;
   options.gzip = options.gzip != null ? options.gzip : false;
+  options.fingerprints = options.fingerprints || isProduction ? true : false
 
   if (options.buildDir.replace) {
     options.buildDir = options.buildDir.replace(/^\//, "").replace(/\/$/, "");

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -86,7 +86,7 @@ Assets.prototype.serveAsset = function (req, res, next) {
     return next(err);
   }
 
-  if (!asset || asset.digest !== parts.fingerprint) {
+  if (!asset || (asset.digest !== parts.fingerprint && this.options.fingerprints)) {
     return next();
   }
 
@@ -152,7 +152,8 @@ Assets.prototype.helper = function (tagWriter, ext) {
         path = "/" + path;
       }
 
-      return tagWriter(path.replace(/(\.[^.]+)$/, "-" + asset.digest + "$1"), attributes);
+      var url = instance.options.fingerprints ? path.replace(/(\.[^.]+)$/, "-" + asset.digest + "$1") : path;
+      return tagWriter(url, attributes);
     };
 
     if (!instance.options.build && asset.type === "bundled") {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     }
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha --reporter spec && ./node_modules/.bin/mocha --require blanket --reporter travis-cov",
+    "test": "./node_modules/mocha/bin/mocha --reporter spec && ./node_modules/mocha/bin/mocha --require blanket --reporter travis-cov",
     "test-watch": "./node_modules/.bin/mocha --reporter min --watch",
     "test-cov-report": "./node_modules/.bin/mocha --require blanket --reporter html-cov > coverage.html && open coverage.html"
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     }
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --reporter spec && ./node_modules/mocha/bin/mocha --require blanket --reporter travis-cov",
+    "test": "./node_modules/.bin/mocha --reporter spec && ./node_modules/.bin/mocha --require blanket --reporter travis-cov",
     "test-watch": "./node_modules/.bin/mocha --reporter min --watch",
     "test-cov-report": "./node_modules/.bin/mocha --require blanket --reporter html-cov > coverage.html && open coverage.html"
   }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -27,7 +27,7 @@ describe("helper functions", function () {
 
   it("returns many paths if options.build is false", function () {
     var ctx = {};
-    var instance = assets({ helperContext: ctx, paths: "test/assets/css", build: false });
+    var instance = assets({ helperContext: ctx, paths: "test/assets/css", build: false, fingerprints: true });
     var files = ctx.assetPath("depends-on-blank.css");
 
     expect(files).to.equal(
@@ -38,16 +38,24 @@ describe("helper functions", function () {
 
   it("returns a single path if options.build is true", function () {
     var ctx = {};
-    var instance = assets({ helperContext: ctx, paths: "test/assets/css", build: true });
+    var instance = assets({ helperContext: ctx, paths: "test/assets/css", build: true, fingerprints: true });
     var files = ctx.assetPath("depends-on-blank.css");
 
     expect(files).to.equal('/assets/depends-on-blank-20c863f1d9051886da2f5fdc3babb547.css');
   });
 
+  it("returns a path without fingerprints if option is set to false", function () {
+    var ctx = {};
+    var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprints: false });
+    var files = ctx.assetPath("blank.css");
+
+    expect(files).to.equal('/assets/blank.css');
+  });
+
   describe("css", function () {
     it("returns a <link> tag for each asset found (separated by \\n)", function () {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprints: true });
       var link = ctx.css("depends-on-blank.css");
 
       expect(link).to.equal(
@@ -58,7 +66,7 @@ describe("helper functions", function () {
 
     it("should serve correct asset even if extention is not supplied", function() {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprints: true });
       var link = ctx.css("asset");
       expect(link).to.equal(
         '<link rel="stylesheet" href="/assets/asset-43cb29c66d0fd6194738cc0fb51afb22.css" />'
@@ -67,7 +75,7 @@ describe("helper functions", function () {
 
     it("should have additional attributes in result tag", function() {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprints: true });
       var link = ctx.css("asset", { 'data-turbolinks-track': true });
       expect(link).to.equal(
         '<link rel="stylesheet" href="/assets/asset-43cb29c66d0fd6194738cc0fb51afb22.css" data-turbolinks-track />'
@@ -79,7 +87,7 @@ describe("helper functions", function () {
   describe("js", function () {
     it("returns a <script> tag for each asset found (separated by \\n)", function () {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js", fingerprints: true });
       var script = ctx.js("depends-on-blank.js");
 
       expect(script).to.equal(
@@ -90,7 +98,7 @@ describe("helper functions", function () {
 
     it("should serve correct asset even if extention is not supplied", function() {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js", fingerprints: true });
       var script = ctx.js("asset.js");
 
       expect(script).to.equal(
@@ -100,7 +108,7 @@ describe("helper functions", function () {
 
     it("should have additional attributes in result tag", function() {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js", fingerprints: true });
       var script = ctx.js("asset.js", { async: true });
 
       expect(script).to.equal(
@@ -112,7 +120,7 @@ describe("helper functions", function () {
   describe("assetPath", function () {
     it("returns a file path for each asset found (separated by \\n)", function () {
       var ctx = {};
-      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js", fingerprints: true });
       var path = ctx.assetPath("depends-on-blank.js");
 
       expect(path).to.equal(

--- a/test/parseOptions.js
+++ b/test/parseOptions.js
@@ -38,6 +38,18 @@ describe("parseOptions", function () {
     });
   });
 
+  describe("fingerprints", function () {
+    it("defaults to false", function () {
+      var opts = assets._parseOptions({});
+      expect(opts.fingerprints).to.equal(false);
+    });
+
+    it("can be overridden", function () {
+      var opts = assets._parseOptions({ fingerprints: true });
+      expect(opts.fingerprints).to.equal(true);
+    });
+  });
+
   describe("servePath", function () {
     it("defaults to 'assets'", function () {
       var opts = assets._parseOptions({});

--- a/test/serveAsset.paths.js
+++ b/test/serveAsset.paths.js
@@ -66,7 +66,7 @@ describe("serveAsset paths", function () {
   });
 
   it("does not serve asset if fingerprint doesn't match", function (done) {
-    createServer.call(this, {}, function () {
+    createServer.call(this, {fingerprints: true}, function () {
       var path = this.assetPath("blank.js").replace(/[a-f0-9]{32}/i, "436828974cd5282217fcbd406d41e9ca");
       var url = this.host + path;
 
@@ -78,12 +78,24 @@ describe("serveAsset paths", function () {
   });
 
   it("does not serve asset if fingerprint isn't supplied", function (done) {
-    createServer.call(this, {}, function () {
+    createServer.call(this, {fingerprints: true}, function () {
       var path = this.assetPath("blank.js").replace(/\-[a-f0-9]{32}/i, "");
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(404);
+        done();
+      });
+    });
+  });
+
+  it("serves asset if fingerprint isn't supplied and option to false", function (done) {
+    createServer.call(this, {fingerprints: false}, function () {
+      var path = this.assetPath("blank.js").replace(/\-[a-f0-9]{32}/i, "");
+      var url = this.host + path;
+
+      http.get(url, function (res) {
+        expect(res.statusCode).to.equal(200);
         done();
       });
     });


### PR DESCRIPTION
As from the issue I opened: https://github.com/adunkman/connect-assets/issues/290
I added an option `fingerprints`, defaulted to `true` in prod, `false` in dev, acting the Sprocket way.

I added some tests, though I never managed to run them because `npm install --dev` fails due to some circular dependency issue, using `npm 2.2.0` and `node 0.10.25`. Here's my console output:

```
$ npm install --dev 
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@1.21.4' from dependencies
npm WARN package.json Dependency 'blanket' exists in both dependencies and devDependencies, using 'blanket@1.1.6' from dependencies
npm WARN package.json Dependency 'expect.js' exists in both dependencies and devDependencies, using 'expect.js@0.3.1' from dependencies
npm WARN package.json Dependency 'travis-cov' exists in both dependencies and devDependencies, using 'travis-cov@0.2.5' from dependencies
npm WARN package.json Dependency 'connect' exists in both dependencies and devDependencies, using 'connect@3.2.0' from dependencies
npm WARN package.json Dependency 'ejs' exists in both dependencies and devDependencies, using 'ejs@1.0.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'serve' exists in both dependencies and devDependencies, using 'serve@*' from dependencies
npm WARN package.json Dependency 'istanbul' exists in both dependencies and devDependencies, using 'istanbul@0.3.2' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@~1.21.4' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@~4.0.0' from dependencies
npm WARN package.json Dependency 'supertest' exists in both dependencies and devDependencies, using 'supertest@~0.13.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@*' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'nodeunit' exists in both dependencies and devDependencies, using 'nodeunit@^0.9.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@1.x.x' from dependencies
npm WARN package.json Dependency 'chai' exists in both dependencies and devDependencies, using 'chai@1.x.x' from dependencies
npm WARN package.json Dependency 'istanbul' exists in both dependencies and devDependencies, using 'istanbul@0.3.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@~1.21.4' from dependencies
npm WARN package.json Dependency 'readable-stream' exists in both dependencies and devDependencies, using 'readable-stream@~1.0.27' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@~4.0.1' from dependencies
npm WARN package.json Dependency 'supertest' exists in both dependencies and devDependencies, using 'supertest@~0.13.0' from dependencies
npm WARN package.json Dependency 'benchmark' exists in both dependencies and devDependencies, using 'benchmark@1.0.0' from dependencies
npm WARN package.json Dependency 'beautify-benchmark' exists in both dependencies and devDependencies, using 'beautify-benchmark@0.2.4' from dependencies
npm WARN package.json Dependency 'fast-url-parser' exists in both dependencies and devDependencies, using 'fast-url-parser@~1.0.0' from dependencies
npm WARN package.json Dependency 'istanbul' exists in both dependencies and devDependencies, using 'istanbul@0.3.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@~1.21.4' from dependencies
npm WARN package.json Dependency 'browserify' exists in both dependencies and devDependencies, using 'browserify@5.11.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'express' exists in both dependencies and devDependencies, using 'express@3.1.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@1.19.0' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@3.3.1' from dependencies
npm WARN package.json Dependency 'coffee-script' exists in both dependencies and devDependencies, using 'coffee-script@~1.7.1' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@~4.0.0' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@>= 0.0.1' from dependencies
npm WARN package.json Dependency 'phantomjs' exists in both dependencies and devDependencies, using 'phantomjs@0.2.2' from dependencies
npm WARN package.json Dependency 'tap' exists in both dependencies and devDependencies, using 'tap@~0.2.6' from dependencies
npm WARN package.json Dependency 'browserify' exists in both dependencies and devDependencies, using 'browserify@latest' from dependencies
npm WARN package.json Dependency 'mocha-better-spec-reporter' exists in both dependencies and devDependencies, using 'mocha-better-spec-reporter@latest' from dependencies
npm WARN package.json Dependency 'gulp-uglify' exists in both dependencies and devDependencies, using 'gulp-uglify@^1.0.1' from dependencies
npm WARN package.json Dependency 'gulp-util' exists in both dependencies and devDependencies, using 'gulp-util@^2.2.14' from dependencies
npm WARN package.json Dependency 'gulp' exists in both dependencies and devDependencies, using 'gulp@^3.8.10' from dependencies
npm WARN package.json Dependency 'vinyl-source-stream2' exists in both dependencies and devDependencies, using 'vinyl-source-stream2@^0.1.1' from dependencies
npm WARN package.json Dependency 'gulp-load-plugins' exists in both dependencies and devDependencies, using 'gulp-load-plugins@^0.5.1' from dependencies
npm WARN package.json Dependency 'gulp-rename' exists in both dependencies and devDependencies, using 'gulp-rename@^1.2.0' from dependencies
npm WARN package.json Dependency 'gulp-header' exists in both dependencies and devDependencies, using 'gulp-header@^1.2.2' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@latest' from dependencies
npm WARN package.json Dependency 'zuul' exists in both dependencies and devDependencies, using 'zuul@latest' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'expect.js' exists in both dependencies and devDependencies, using 'expect.js@*' from dependencies
npm WARN package.json Dependency 'serve' exists in both dependencies and devDependencies, using 'serve@*' from dependencies
npm WARN package.json Dependency 'assetgraph' exists in both dependencies and devDependencies, using 'assetgraph@=1.0.1' from dependencies
npm WARN package.json Dependency 'assetgraph-builder' exists in both dependencies and devDependencies, using 'assetgraph-builder@=1.0.3' from dependencies
npm WARN package.json Dependency 'jamjs' exists in both dependencies and devDependencies, using 'jamjs@=0.2.17' from dependencies
npm WARN package.json Dependency 'optimist' exists in both dependencies and devDependencies, using 'optimist@=0.3.1' from dependencies
npm WARN package.json Dependency 'uglify-js' exists in both dependencies and devDependencies, using 'uglify-js@=2.4.15' from dependencies
npm WARN package.json Dependency 'vows' exists in both dependencies and devDependencies, using 'vows@=0.7.0' from dependencies
npm WARN package.json Dependency 'tape' exists in both dependencies and devDependencies, using 'tape@~1.0.4' from dependencies
npm WARN package.json Dependency 'tap' exists in both dependencies and devDependencies, using 'tap@~0.4.0' from dependencies
npm WARN package.json Dependency 'covert' exists in both dependencies and devDependencies, using 'covert@^1.0.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@~1.17.1' from dependencies
npm WARN package.json Dependency 'supertest' exists in both dependencies and devDependencies, using 'supertest@~0.9.0' from dependencies
npm WARN package.json Dependency 'express' exists in both dependencies and devDependencies, using 'express@~3.4.7' from dependencies
npm WARN package.json Dependency 'fs-extra' exists in both dependencies and devDependencies, using 'fs-extra@~0.11.0' from dependencies
npm WARN package.json Dependency 'benchmark' exists in both dependencies and devDependencies, using 'benchmark@*' from dependencies
npm WARN package.json Dependency 'uglify-js' exists in both dependencies and devDependencies, using 'uglify-js@~2.4.0' from dependencies
npm WARN package.json Dependency 'source-map' exists in both dependencies and devDependencies, using 'source-map@~0.1.27' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@1.17.x' from dependencies
npm WARN package.json Dependency 'gulp-es6-transpiler' exists in both dependencies and devDependencies, using 'gulp-es6-transpiler@1.0.0' from dependencies
npm WARN package.json Dependency 'gulp-json-editor' exists in both dependencies and devDependencies, using 'gulp-json-editor@2.0.2' from dependencies
npm WARN package.json Dependency 'jshint-stylish' exists in both dependencies and devDependencies, using 'jshint-stylish@1.0.0' from dependencies
npm WARN package.json Dependency 'gulp-jshint' exists in both dependencies and devDependencies, using 'gulp-jshint@1.8.4' from dependencies
npm WARN package.json Dependency 'gonzales-pe' exists in both dependencies and devDependencies, using 'gonzales-pe@3.0.0-10' from dependencies
npm WARN package.json Dependency 'gulp-mocha' exists in both dependencies and devDependencies, using 'gulp-mocha@1.1.0' from dependencies
npm WARN package.json Dependency 'gulp-util' exists in both dependencies and devDependencies, using 'gulp-util@3.0.1' from dependencies
npm WARN package.json Dependency 'fs-extra' exists in both dependencies and devDependencies, using 'fs-extra@0.12.0' from dependencies
npm WARN package.json Dependency 'gonzales' exists in both dependencies and devDependencies, using 'gonzales@1.0.7' from dependencies
npm WARN package.json Dependency 'request' exists in both dependencies and devDependencies, using 'request@2.44.0' from dependencies
npm WARN package.json Dependency 'rework' exists in both dependencies and devDependencies, using 'rework@1.0.1' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@4.0.4' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@1.21.4' from dependencies
npm WARN package.json Dependency 'cssom' exists in both dependencies and devDependencies, using 'cssom@0.3.0' from dependencies
npm WARN package.json Dependency 'gulp' exists in both dependencies and devDependencies, using 'gulp@3.8.8' from dependencies
npm WARN package.json Dependency 'es6-transpiler' exists in both dependencies and devDependencies, using 'es6-transpiler@0.7.16' from dependencies
npm WARN package.json Dependency 'grunt' exists in both dependencies and devDependencies, using 'grunt@~0.4.1' from dependencies
npm WARN package.json Dependency 'grunt-contrib-jshint' exists in both dependencies and devDependencies, using 'grunt-contrib-jshint@~0.6.4' from dependencies
npm WARN package.json Dependency 'jshint-stylish' exists in both dependencies and devDependencies, using 'jshint-stylish@latest' from dependencies
npm WARN package.json Dependency 'acorn' exists in both dependencies and devDependencies, using 'acorn@~0.3.1' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@~1.12.1' from dependencies
npm WARN package.json Dependency 'grunt-cli' exists in both dependencies and devDependencies, using 'grunt-cli@~0.1.9' from dependencies
npm WARN package.json Dependency 'bluebird' exists in both dependencies and devDependencies, using 'bluebird@~0.11' from dependencies
npm WARN package.json Dependency 'benchmark' exists in both dependencies and devDependencies, using 'benchmark@~1.0.0' from dependencies
npm WARN package.json Dependency 'deque' exists in both dependencies and devDependencies, using 'deque@0.0.4' from dependencies
npm WARN package.json Dependency 'q' exists in both dependencies and devDependencies, using 'q@~0.9.7' from dependencies
npm WARN package.json Dependency 'semver-utils' exists in both dependencies and devDependencies, using 'semver-utils@~1.1.0' from dependencies
npm WARN package.json Dependency 'tap' exists in both dependencies and devDependencies, using 'tap@*' from dependencies
npm WARN package.json Dependency 'nodeunit' exists in both dependencies and devDependencies, using 'nodeunit@~0.7.4' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@~1.6' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@~1.2' from dependencies
npm WARN package.json Dependency 'tap' exists in both dependencies and devDependencies, using 'tap@~0.4.8' from dependencies
npm WARN package.json Dependency 'browserify' exists in both dependencies and devDependencies, using 'browserify@latest' from dependencies
npm WARN package.json Dependency 'mocha-better-spec-reporter' exists in both dependencies and devDependencies, using 'mocha-better-spec-reporter@0.0.2' from dependencies
npm WARN package.json Dependency 'gulp-mocha' exists in both dependencies and devDependencies, using 'gulp-mocha@^0.4.1' from dependencies
npm WARN package.json Dependency 'gulp-uglify' exists in both dependencies and devDependencies, using 'gulp-uglify@^0.3.0' from dependencies
npm WARN package.json Dependency 'gulp-util' exists in both dependencies and devDependencies, using 'gulp-util@^2.2.14' from dependencies
npm WARN package.json Dependency 'gulp' exists in both dependencies and devDependencies, using 'gulp@^3.6.2' from dependencies
npm WARN package.json Dependency 'vinyl-source-stream2' exists in both dependencies and devDependencies, using 'vinyl-source-stream2@^0.1.1' from dependencies
npm WARN package.json Dependency 'gulp-load-plugins' exists in both dependencies and devDependencies, using 'gulp-load-plugins@^0.5.1' from dependencies
npm WARN package.json Dependency 'gulp-rename' exists in both dependencies and devDependencies, using 'gulp-rename@^1.2.0' from dependencies
npm WARN package.json Dependency 'gulp-header' exists in both dependencies and devDependencies, using 'gulp-header@^1.0.2' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@^1.19.0' from dependencies
npm WARN package.json Dependency 'zuul' exists in both dependencies and devDependencies, using 'zuul@^1.6.5' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@>= 0.0.1' from dependencies
npm WARN package.json Dependency 'tape' exists in both dependencies and devDependencies, using 'tape@~2.12.3' from dependencies
npm WARN package.json Dependency 'vinyl-map' exists in both dependencies and devDependencies, using 'vinyl-map@1.0.1' from dependencies
npm WARN package.json Dependency 'gulp-rename' exists in both dependencies and devDependencies, using 'gulp-rename@~1.2.0' from dependencies
npm WARN package.json Dependency 'gulp' exists in both dependencies and devDependencies, using 'gulp@~3.6.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@^2.0.0' from dependencies
npm WARN package.json Dependency 'mocha-better-spec-reporter' exists in both dependencies and devDependencies, using 'mocha-better-spec-reporter@latest' from dependencies
npm WARN package.json Dependency 'nodeunit' exists in both dependencies and devDependencies, using 'nodeunit@>0.0.0' from dependencies
npm WARN package.json Dependency 'uglify-js' exists in both dependencies and devDependencies, using 'uglify-js@1.2.x' from dependencies
npm WARN package.json Dependency 'nodelint' exists in both dependencies and devDependencies, using 'nodelint@>0.0.0' from dependencies
npm WARN package.json Dependency 'browserify' exists in both dependencies and devDependencies, using 'browserify@6.1.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'event-stream' exists in both dependencies and devDependencies, using 'event-stream@^3.1.7' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@*' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@*' from dependencies
npm WARN package.json Dependency 'vinyl' exists in both dependencies and devDependencies, using 'vinyl@*' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@>= 0.0.1' from dependencies
npm WARN package.json Dependency 'jshint' exists in both dependencies and devDependencies, using 'jshint@^2.5.1' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@^1.18.2' from dependencies
npm WARN package.json Dependency 'proxyquire' exists in both dependencies and devDependencies, using 'proxyquire@^1.0.1' from dependencies
npm WARN package.json Dependency 'sinon' exists in both dependencies and devDependencies, using 'sinon@^1.9.1' from dependencies
npm WARN package.json Dependency 'coveralls' exists in both dependencies and devDependencies, using 'coveralls@^2.7.0' from dependencies
npm WARN package.json Dependency 'graceful-fs' exists in both dependencies and devDependencies, using 'graceful-fs@^3.0.0' from dependencies
npm WARN package.json Dependency 'istanbul' exists in both dependencies and devDependencies, using 'istanbul@^0.3.0' from dependencies
npm WARN package.json Dependency 'jshint' exists in both dependencies and devDependencies, using 'jshint@^2.5.0' from dependencies
npm WARN package.json Dependency 'jshint-stylish' exists in both dependencies and devDependencies, using 'jshint-stylish@^1.0.0' from dependencies
npm WARN package.json Dependency 'marked-man' exists in both dependencies and devDependencies, using 'marked-man@^0.1.3' from dependencies
npm WARN package.json Dependency 'mkdirp' exists in both dependencies and devDependencies, using 'mkdirp@^0.5.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@^2.0.1' from dependencies
npm WARN package.json Dependency 'mocha-lcov-reporter' exists in both dependencies and devDependencies, using 'mocha-lcov-reporter@^0.0.1' from dependencies
npm WARN package.json Dependency 'q' exists in both dependencies and devDependencies, using 'q@^1.0.0' from dependencies
npm WARN package.json Dependency 'rimraf' exists in both dependencies and devDependencies, using 'rimraf@^2.2.5' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@^4.0.0' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@latest' from dependencies
npm WARN package.json Dependency 'tap' exists in both dependencies and devDependencies, using 'tap@~0.4.0' from dependencies
npm WARN package.json Dependency 'map-stream' exists in both dependencies and devDependencies, using 'map-stream@>=0.0.4' from dependencies
npm WARN package.json Dependency 'mocha' exists in both dependencies and devDependencies, using 'mocha@>=1.15.0' from dependencies
npm WARN package.json Dependency 'should' exists in both dependencies and devDependencies, using 'should@>=2.1.0' from dependencies
npm WARN package.json Dependency 'gulp' exists in both dependencies and devDependencies, using 'gulp@>=3.0.0' from dependencies
npm WARN package.json Dependency 'gulp-jshint' exists in both dependencies and devDependencies, using 'gulp-jshint@>=1.1.0' from dependencies
npm WARN package.json Dependency 'argg' exists in both dependencies and devDependencies, using 'argg@0.0.1' from dependencies
npm WARN package.json Dependency 'codeclimate-test-reporter' exists in both dependencies and devDependencies, using 'codeclimate-test-reporter@0.0.3' from dependencies
npm WARN package.json Dependency 'gulp-concat' exists in both dependencies and devDependencies, using 'gulp-concat@>=2.3.4 <3.0.0-0' from dependencies
npm WARN package.json Dependency 'gulp-sourcemaps' exists in both dependencies and devDependencies, using 'gulp-sourcemaps@>=1.1.1 <2.0.0-0' from dependencies
npm WARN package.json Dependency 'istanbul' exists in both dependencies and devDependencies, using 'istanbul@>=0.3.0 <0.4.0-0' from dependencies
npm WARN package.json Dependency 'rimraf' exists in both dependencies and devDependencies, using 'rimraf@>=2.2.8 <3.0.0-0' from dependencies
npm WARN package.json Dependency 'tape' exists in both dependencies and devDependencies, using 'tape@>=2.12.3 <3.0.0-0' from dependencies
npm WARN package.json Dependency 'vinyl' exists in both dependencies and devDependencies, using 'vinyl@>=0.3.2 <0.4.0-0' from dependencies
```

I am willing to try to fix that but I don't know how yet.