### PR TITLE
bug: permit null pathname for servePath.

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,12 @@ var parseOptions = module.exports._parseOptions = function (options) {
   var isProduction = process.env.NODE_ENV === "production";
   var isDevelopment = !isProduction;
   var servePath = (options.servePath || "assets");
+  var servePathPathname = parseUrl(servePath).pathname || "/";
 
   options.paths = arrayify(options.paths || options.src || [ "assets/js", "assets/css" ]);
   options.helperContext = options.helperContext || global;
   options.servePath = servePath.replace(/^\//, "").replace(/\/$/, "");
-  options.localServePath = options.localServePath || parseUrl(servePath).pathname.replace(/^\//, "");
+  options.localServePath = options.localServePath || servePathPathname.replace(/^\//, "");
   options.precompile = arrayify(options.precompile || ["*.*"]);
   options.build = options.build != null ? options.build : isProduction;
   options.buildDir = options.buildDir != null ? options.buildDir : isDevelopment ? false : "builtAssets";

--- a/test/serveAsset.paths.js
+++ b/test/serveAsset.paths.js
@@ -39,6 +39,16 @@ describe("serveAsset paths", function () {
     });
   });
 
+  it("allows servePath to be a URL without a protocol and without a pathname", function (done) {
+    createServer.call(this, { servePath: "//cdn.example.com" }, function () {
+      var path = this.assetPath("blank.js");
+      var url = path;
+
+      expect(path.indexOf("//cdn.example.com/")).to.equal(0);
+      done();
+    });
+  });
+
   it("serves assets at the pathname of servePath if servePath is a URL", function (done) {
     createServer.call(this, { servePath: "http://cdn.example.com:2452/assets" }, function () {
       var path = this.assetPath("blank.js");


### PR DESCRIPTION
ran into this today. no trailing slash on `servePath` results in null `pathname`.
```javascript
> require('url').parse('//cdn.example.com', false, true).pathname
null
```