### PR TITLE
Update Mincer to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "argparse": "0.1.16",
     "csswring": "3.0.0",
-    "mincer": "1.2.2",
+    "mincer": "1.2.4",
     "uglify-js": "2.4.16"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating Mincer to 1.2.4 resolves issue #289, because of nodeca/mincer#186, which translates into compatibility with sass/node-sass 2 and ultimately Node 0.12. Whew!