### PR TITLE
Fix crash which happens when a req.url begins with //

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var connectAssets = module.exports = function (options, configureCallback) {
   });
 
   var middleware = function (req, res, next) {
-    var path = parseUrl(req.url).pathname.replace(/^\//, "");
+    var path = url.parse(req.url).pathname.replace(/^\//, "");
 
     if (path.toLowerCase().indexOf(options.localServePath.toLowerCase()) === 0) {
       var serve = function (req, res, next) {
@@ -59,7 +59,7 @@ var parseOptions = module.exports._parseOptions = function (options) {
   var isProduction = process.env.NODE_ENV === "production";
   var isDevelopment = !isProduction;
   var servePath = (options.servePath || "assets");
-  var servePathPathname = parseUrl(servePath).pathname || "/";
+  var servePathPathname = url.parse(servePath, false, true).pathname || "/";
 
   options.paths = arrayify(options.paths || options.src || [ "assets/js", "assets/css" ]);
   options.helperContext = options.helperContext || global;
@@ -86,12 +86,6 @@ var arrayify = module.exports._arrayify = function (target) {
 
 var pasteAttr = function (attributes) {
   return !!attributes ? ' ' + attributes : '';
-};
-
-var parseUrl = function (string) {
-  var parseQueryString = false;
-  var allowUrlWithoutProtocol = true;
-  return url.parse(string, parseQueryString, allowUrlWithoutProtocol);
 };
 
 var tagWriters = {

--- a/test/serveAsset.paths.js
+++ b/test/serveAsset.paths.js
@@ -77,6 +77,17 @@ describe("serveAsset paths", function () {
     });
   });
 
+  it("correctly handles a req.url that begin with a double slash", function (done) {
+    createServer.call(this, {}, function () {
+      var url = this.host + '//foo';
+
+      http.get(url, function (res) {
+        expect(res.statusCode).to.equal(404);
+        done();
+      });
+    });
+  });
+
   it("does not serve assets for URLs outside of serve path", function (done) {
     createServer.call(this, {}, function () {
       var path = this.assetPath("blank.js").replace("/assets", "");


### PR DESCRIPTION
If the url looked like `//foo` the middleware was parsing the `// `as a host so the parsed object would look like 
```javascript
{ protocol: null,
  slashes: true,
  auth: null,
  host: 'foo',
  port: null,
  hostname: 'foo',
  hash: null,
  search: null,
  query: null,
  pathname: null,
  path: null,
  href: '//foo' }
```

It would then try to do a replace on the pathname which is null.

This PR only parses `//` as a host in the servepath, not in `req,path`