### PR TITLE
Fix compiling with binary and serving pre-compiled assets

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,6 +1,7 @@
 var mincer = require("mincer");
 var url = require("url");
 var http = require("http");
+var fs = require("fs");
 
 var Assets = module.exports = function (options) {
   this.options = options;
@@ -32,7 +33,7 @@ Assets.prototype.compile = function (callback) {
   var instance = this;
 
   if (!this.options.compile) {
-    return;
+    return callback();
   }
   if (this.manifest) {
     try {
@@ -72,11 +73,17 @@ Assets.prototype.serveAsset = function (req, res, next) {
   }
 
   var parts = parse(path);
-  var asset;
+  var asset, assetName;
 
   try {
     if (!this.options.compile) {
-      asset = this.manifest.assets[parts.path];
+      assetName = this.manifest.assets[parts.path];
+      asset = this.manifest.files[assetName];
+
+      if(asset) {
+        asset.mtime = new Date(asset.mtime);
+        asset.length = asset.size;
+      }
     }
     else {
       asset = this.environment.findAsset(parts.path, { bundle: this.options.build });
@@ -102,15 +109,24 @@ Assets.prototype.serveAsset = function (req, res, next) {
 
   var contentType = asset.contentType;
 
-  if (contentType.match(/^text\/|\/json$|\/javascript$/)) {
-    contentType += "; charset=UTF-8";
-  }
+  if (contentType) {
+    if (contentType.match(/^text\/|\/json$|\/javascript$/)) {
+      contentType += "; charset=UTF-8";
+    }
 
-  res.setHeader("Content-Type", contentType);
+    res.setHeader("Content-Type", contentType);
+  }
   res.setHeader("Content-Length", asset.length);
 
   if (req.method === "HEAD") {
     return res.end();
+  }
+
+  if (!asset.buffer) {
+    return fs.readFile(this.options.buildDir + "/" + assetName, function (err, data) {
+      if (err) return next(err);
+      res.end(data.toString());
+    });
   }
 
   res.end(asset.buffer);

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -3,6 +3,7 @@ var url = require("url");
 var http = require("http");
 var fs = require("fs");
 var pathModule = require("path");
+var mime = require("mime");
 
 var Assets = module.exports = function (options) {
   this.options = options;
@@ -84,6 +85,7 @@ Assets.prototype.serveAsset = function (req, res, next) {
       if(asset) {
         asset.mtime = new Date(asset.mtime);
         asset.length = asset.size;
+        asset.contentType = mime.lookup(pathModule.join(this.options.buildDir, assetName));
       }
     }
     else {
@@ -127,7 +129,7 @@ Assets.prototype.serveAsset = function (req, res, next) {
     var localFilePath = pathModule.join(this.options.buildDir, assetName);
     return fs.readFile(localFilePath, function (err, data) {
       if (err) return next(err);
-      res.end(data.toString());
+      res.end(data);
     });
   }
 

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -2,6 +2,7 @@ var mincer = require("mincer");
 var url = require("url");
 var http = require("http");
 var fs = require("fs");
+var pathModule = require("path");
 
 var Assets = module.exports = function (options) {
   this.options = options;
@@ -123,7 +124,8 @@ Assets.prototype.serveAsset = function (req, res, next) {
   }
 
   if (!asset.buffer) {
-    return fs.readFile(this.options.buildDir + "/" + assetName, function (err, data) {
+    var localFilePath = pathModule.join(this.options.buildDir, assetName);
+    return fs.readFile(localFilePath, function (err, data) {
       if (err) return next(err);
       res.end(data.toString());
     });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "argparse": "0.1.16",
     "csswring": "3.0.0",
+    "mime": "^1.3.4",
     "mincer": "1.2.2",
     "uglify-js": "2.4.16"
   },

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -104,6 +104,7 @@ describe("serveAsset filesystem", function () {
           http.get(url, function (res) {
             expect(res.statusCode).to.equal(200);
             expect(fs.statSync(dir).isDirectory()).to.equal(true);
+            expect(res.headers).to.have.property("content-type");
 
             var data = "";
 


### PR DESCRIPTION
This pull request fixes invalid behavior of connect-asset when serving pre-compiled assets.

I had to fix a few issues where asset suddenly was an object and not an instance of mincers `Asset` class. Since the object does not contain the buffer, we also have to go and read it from the file system.

The manifest also does not contain the contentType anymore, so we cannot really say what kind of file it is, so I moved that part into a conditional block.

Please let me know what you think! :beers: 