### PR TITLE
Add option to helper functions to render assets inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ Results in:
 <script src="/js/jquery-[hash].js" async></script>
 ```
 
+You can also use include the bundle contents directly.  This still supports an option attributes Hash.
+
+```
+!= css("critical-path", { type: 'text/css' }, true)
+!= js("critical-path", true)
+```
+
+Results in:
+
+```html
+<style>/* contents of critical-path.css */</style>
+<script>/* contents of critical-path.js */</script>
+```
+
 ### Sprockets-style concatenation
 
 You can indicate dependencies in your `.js.coffee` and `.js` files using the Sprockets-style syntax.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Results in:
 <script src="/js/jquery-[hash].js" async></script>
 ```
 
-You can also use include the bundle contents directly.  This still supports an option attributes Hash.
+You can also use include the bundle contents directly.  This still supports an optional attributes Hash.
 
 ```
 != css("critical-path", { type: 'text/css' }, true)

--- a/index.js
+++ b/index.js
@@ -95,7 +95,13 @@ var parseUrl = function (string) {
 };
 
 var tagWriters = {
-  css: function (url, attr) { return '<link rel="stylesheet" href="' + url + '"' + pasteAttr(attr) + ' />'; },
-  js: function (url, attr) { return '<script src="' + url + '"' + pasteAttr(attr) + '></script>'; },
+  css: function (url, attr, asset) {
+    if (!asset) return '<link rel="stylesheet" href="' + url + '"' + pasteAttr(attr) + ' />';
+    else return '<style' +  pasteAttr(attr) + '>' + asset.toString().trim() + '</style>';
+  },
+  js: function (url, attr, asset) {
+    if (!asset) return '<script src="' + url + '"' + pasteAttr(attr) + '></script>';
+    else return '<script' + pasteAttr(attr) + '>' + asset.toString().trim() + '</script>';
+  },
   noop: function (url) { return url; }
 };

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -119,11 +119,16 @@ Assets.prototype.serveAsset = function (req, res, next) {
 Assets.prototype.helper = function (tagWriter, ext) {
   var instance = this;
 
-  return function (path, options) {
+  return function (path, options, inline) {
     var asset;
     var regExp = new RegExp("\\." + ext + "$");
     var pathHasNoExt = !regExp.test(path);
 
+    if (options === true && typeof inline === "undefined") {
+      options = null;
+      inline = true;
+    }
+    
     if (ext && pathHasNoExt) {
       path = path + "." + ext;
     }
@@ -156,7 +161,7 @@ Assets.prototype.helper = function (tagWriter, ext) {
         path = path.replace(/(\.[^.]+)$/, "-" + asset.digest + "$1");
       }
 
-      return tagWriter(path, attributes);
+      return tagWriter(path, attributes, inline === true ? asset : null);
     };
 
     if (!instance.options.build && asset.type === "bundled") {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 var expect = require("expect.js");
 var mocha = require("mocha");
 var assets = require("..");
+var fs = require("fs");
 
 describe("helper functions", function () {
   it("do not pollute global scope if helperContext is passed", function () {
@@ -90,6 +91,28 @@ describe("helper functions", function () {
       );
     });
 
+    it("should return a <style> tag with inline css", function () {
+      var ctx = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var styleContents = fs.readFileSync('test/assets/css/unminified.css', 'UTF-8');
+      var style = ctx.css("unminified", true);
+
+      expect(style).to.equal(
+        '<style>' + styleContents.trim() + '</style>'
+      );
+    });
+
+    it("should return a <style> tag with inline css and attributes", function () {
+      var ctx = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var styleContents = fs.readFileSync('test/assets/css/unminified.css', 'UTF-8');
+      var style = ctx.css("unminified", { type: 'text/css' }, true);
+
+      expect(style).to.equal(
+        '<style type="text/css">' + styleContents.trim() + '</style>'
+      );
+    });
+
   });
 
   describe("js", function () {
@@ -123,6 +146,29 @@ describe("helper functions", function () {
         '<script src="/assets/asset.js" async></script>'
       );
     });
+
+    it("should return a <script> tag with inine js", function () {
+      var ctx = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var scriptContent = fs.readFileSync("test/assets/js/unminified.js", "UTF-8");
+      var script = ctx.js("unminified.js", true);
+
+      expect(script).to.equal(
+        '<script>' + scriptContent.trim() + '</script>'
+      );
+    });
+
+    it("should return a <script> tag with inine js and attributes", function () {
+      var ctx = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var scriptContent = fs.readFileSync("test/assets/js/unminified.js", "UTF-8");
+      var script = ctx.js("unminified.js", { type: "text/javascript" }, true);
+
+      expect(script).to.equal(
+        '<script type="text/javascript">' + scriptContent.trim() + '</script>'
+      );
+    });
+
   });
 
   describe("assetPath", function () {


### PR DESCRIPTION
Add an optional argument to `css` and `js` helper functions to render contents inline for critical path assets.