### PR TITLE
Bumping to Mincer 1.3.0, Csswring 3.0.5, Uglify JS 2.4.23, and more

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,18 +34,18 @@
     "connect-assets": "bin/connect-assets"
   },
   "dependencies": {
-    "argparse": "0.1.16",
-    "csswring": "3.0.0",
+    "argparse": "1.0.2",
+    "csswring": "3.0.5",
     "mime": "1.3.4",
-    "mincer": "1.2.4",
-    "uglify-js": "2.4.16"
+    "mincer": "1.3.0",
+    "uglify-js": "2.4.23"
   },
   "devDependencies": {
-    "mocha": "2.1.0",
-    "blanket": "1.1.6",
+    "mocha": "2.2.5",
+    "blanket": "1.1.7",
     "expect.js": "0.3.1",
     "travis-cov": "0.2.5",
-    "connect": "3.3.4",
+    "connect": "3.4.0",
     "ejs": "1.0.0"
   },
   "config": {

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -38,7 +38,7 @@ describe("connect-assets command-line interface", function () {
       var js = dir + '/' + manifest.assets['unminified.js'];
 
       expect(fs.readFileSync(css, "utf8")).to.equal("body{background-color:#000;color:#fff}a{display:none}");
-      expect(fs.readFileSync(js, "utf8")).to.equal('!function(){{var n="A string",a={aLongKeyName:function(){return n}};a.aLongKeyName()}}();');
+      expect(fs.readFileSync(js, "utf8")).to.equal('!function(){var n="A string",a={aLongKeyName:function(){return n}};a.aLongKeyName()}();');
 
       rmrf("builtAssets", done);
     });
@@ -93,7 +93,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-730852c545ad888d07333a229acd5ed0.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-0589f66713bc44029a1a720b9a0d850d.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -108,7 +108,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-730852c545ad888d07333a229acd5ed0.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-0589f66713bc44029a1a720b9a0d850d.css\"");
       rmrf("builtAssets", done);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,7 +57,7 @@ describe("helper functions", function () {
     var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprinting: true });
     var files = ctx.assetPath("blank.css");
 
-    expect(files).to.equal("/assets/blank-730852c545ad888d07333a229acd5ed0.css");
+    expect(files).to.equal("/assets/blank-0589f66713bc44029a1a720b9a0d850d.css");
   });
 
   describe("css", function () {

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -13,14 +13,14 @@ describe("serveAsset asset_path environment helper", function () {
 
     createServer.call(this, { buildDir: dir, compile: true, fingerprinting: true }, function () {
       var path = this.assetPath("asset-path-helper.css");
-      var filename = dir + "/asset-path-helper-d93cbe4ed480b3859eefe53f37ed8e55.css";
+      var filename = dir + "/asset-path-helper-791d4908176a09d310ccc381f9306283.css";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-730852c545ad888d07333a229acd5ed0.css\";\n\n");
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-0589f66713bc44029a1a720b9a0d850d.css\";\n\n");
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -67,7 +67,7 @@ describe("serveAsset filesystem", function () {
         http.get(url, function (res) {
           expect(res.statusCode).to.equal(200);
           expect(fs.statSync(dir).isDirectory()).to.equal(true);
-          expect(fs.statSync(dir + "/blank-08b3d4e36caf0fd8570aee1dc4acb64e.css").isFile()).to.equal(true);
+          expect(fs.statSync(dir + "/blank-198068b3cdca651ae033a746f970a50d.css").isFile()).to.equal(true);
 
           process.env.NODE_ENV = env;
           rmrf(dir, done);

--- a/test/serveAsset.minification.js
+++ b/test/serveAsset.minification.js
@@ -14,14 +14,14 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.js");
-      var filename = dir + "/unminified-30503f0739ff23f8af4a83ed0170135a.js";
+      var filename = dir + "/unminified-b563e4856c147f0133a59fc9a7e4ee63.js";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal('!function(){{var n="A string",a={aLongKeyName:function(){return n}};a.aLongKeyName()}}();');
+        expect(fs.readFileSync(filename, "utf8")).to.equal('!function(){var n="A string",a={aLongKeyName:function(){return n}};a.aLongKeyName()}();');
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);
@@ -36,7 +36,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.css");
-      var filename = dir + "/unminified-4eb408a830a8b12f5e106dc4549aa1d4.css";
+      var filename = dir + "/unminified-c0389bd8003d3a89098cdb90e49209c3.css";
       var url = this.host + path;
 
       http.get(url, function (res) {


### PR DESCRIPTION
This is a pretty large chunk of dependency bumps. Highlights include:
* mincer 1.2.4 -> 1.3.0
* uglify-js 2.4.16 -> 2.4.23
* argparse 0.1.16 -> 1.0.2
* csswring 3.0.0 -> 3.0.5

For dev dependencies:
* mocha 2.1.0 -> 2.2.5
* blanket 1.1.6 -> 1.1.7
* connect 3.3.4 -> 3.4.0

Once merged, this should close #307, #308, #310.
This PR supercedes #309, #312.