### PR TITLE
Add autoprefixer support for the command-line utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ app.use(require("connect-assets")(options, function (instance) {
 connect-assets includes a command-line utility, `connect-assets`, which can be used to precompile assets on your filesystem (which you can then upload to your CDN of choice). From your application directory, you can execute it with `./node_modules/.bin/connect-assets [options]`.
 
 ```
-Usage: connect-assets [-h] [-v] [-gz] [-i [DIRECTORY [DIRECTORY ...]]]
+Usage: connect-assets [-h] [-v] [-gz] [-ap] [-i [DIRECTORY [DIRECTORY ...]]]
                       [-c [FILE [FILE ...]]] [-o DIRECTORY]
 
 Precompiles assets supplied into their production-ready form, ready for
@@ -165,6 +165,7 @@ Optional arguments:
   -gz, --gzip
                         Enables gzip file generation, which is disabled by
                         default.
+  -ap, --autoprefixer   Enables autoprefixer during compilation.
 ```
 
 ## Credits

--- a/bin/connect-assets
+++ b/bin/connect-assets
@@ -57,6 +57,12 @@ var initialize = exports.initialize = function () {
     defaultValue: false
   });
 
+  cli.addArgument(["-ap", "--autoprefixer"], {
+    help: "Enables autoprefixer during compilation.",
+    action: 'storeTrue',
+    defaultValue: false
+  });
+
   return cli;
 };
 
@@ -125,6 +131,8 @@ var _compile = exports._compile = function (args, callback) {
     precompile: args.compile,
     fingerprinting: true
   });
+
+  if (args.autoprefixer) { assets.environment.enable('autoprefixer'); }
 
   assets.compile(callback);
 };


### PR DESCRIPTION
In some of my projects, there's an inconsistent behaviour between development & production environment due to `autoprefixer` being supported in the app (via `mincer`) but not in the command-line utility (which I use to precompile assets for production).

This PR adds `autoprefixer` support for the command-line utility via the `-ap` or `--autoprefixer` option.