### PR TITLE
Fix #324 serve source map

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -79,7 +79,7 @@ Assets.prototype.serveAsset = function (req, res, next) {
   }
 
   var parts = parse(path);
-  var asset, assetName;
+  var asset, assetName, sourceMap;
 
   try {
     asset = this.getAssetByPath(parts.path, { bundle: this.options.build });
@@ -90,9 +90,10 @@ Assets.prototype.serveAsset = function (req, res, next) {
       if (!asset || !asset.sourceMap) {
         return next();
       }
-      res.setHeader("Content-Length", asset.sourceMap.length);
+      sourceMap = asset.sourceMap.toString();
+      res.setHeader("Content-Length", sourceMap.length);
       res.setHeader("Content-Type", "application/json");
-      return res.end(asset.sourceMap);
+      return res.end(sourceMap);
     }
 
     if (!asset || (this.options.fingerprinting && asset.digest !== parts.fingerprint)) {


### PR DESCRIPTION
If the asset is not bundled then `asset.sourceMap` may not be a string, but an object, so it is not served correctly.