### PR TITLE
Serve JSX files

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@ var url = require("url");
 var fs = require("fs");
 var Assets = require("./lib/assets");
 
-var connectAssets = module.exports = function (options, configureCallback) {
+var connectAssets = module.exports = function (options, configureCallback, preInitMincerSetup) {
   options = parseOptions(options || {});
 
-  var assets = new Assets(options);
+  var assets = new Assets(options, preInitMincerSetup);
   var compilationComplete = false;
   var compilationError;
   var waiting = [];

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -7,6 +7,7 @@ var mime = require("mime");
 
 var Assets = module.exports = function (options) {
   this.options = options;
+  this.mincer = mincer;
 
   if (this.options.compile) {
     this.environment = new mincer.Environment();

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -5,9 +5,11 @@ var fs = require("fs");
 var pathModule = require("path");
 var mime = require("mime");
 
-var Assets = module.exports = function (options) {
+var Assets = module.exports = function (options, preInitMincerSetup) {
   this.options = options;
-  this.mincer = mincer;
+  if (preInitMincerSetup) {
+    preInitMincerSetup(mincer);
+  }
 
   if (this.options.compile) {
     this.environment = new mincer.Environment();


### PR DESCRIPTION
Regarding #303 I did not get the time to come back earlier but finally did.

The suggested code snippet did not help much. 

```
var Mincer = require('mincer');
require('mincer-jsx')(Mincer);
```

There was a need to explain where the `mincer` comes from, since it should be the same mincer instance that uses `connect-assets`.

So after quite some diving into the different codes (`connect-assets`, `mincer` and `mincer-jsx`), I did two things:

### 1. [Forked `mincer-jsx`](https://github.com/aug-riedinger/mincer-jsx) 

It which was only compatible with mincer 1.2 (which did not match connect-asset dependency). I also fixed its inner behavior and completely removed mincer dependency, only using the `mincer` object which is given by parameter. Much easier to use.

If you need to use it, please use in `package.json`:

```
  "dependencies": {
    "mincer-jsx": "git://github.com/aug-riedinger/mincer-jsx.git#master",
  }
```
until the npm package is merged.

### 2. Forked `connect-assets` (the actual PR)

So basically, `mincer-jsx` needs to access the `mincer` instance used by `connect-assets` and the `mincer.registerEngine()` must be called **before** the `new mincer.Environment();`.

For that reason, I added another callback in the `connectAssets` exports, which I called `preInitMincerSetup`, which is passed to `new Assets(options, preInitMincerSetup)` which does what's expected.

I am not aware if the two callbacks `configureCallback` and `preInitMincerSetup` could be merged into one, since they kind of do the same thing, but not at the same time. I'll let @adunkman to review that and decide.

Finally, the code to use to get this whole thing working is:

`package.json`:

```
  "dependencies": {
    "connect-assets": "git://github.com/aug-riedinger/connect-assets.git#master",
    "mincer-jsx": "git://github.com/aug-riedinger/mincer-jsx.git#master"
  }
```
`server.js`:
```
app.use(require('connect-assets')({}, null, function (mincer) {
  require('mincer-jsx')(mincer);
}));
```

Hope this get merged. Untill then, I'll use my github versions.

Best