### PR TITLE
Expose Mincer outside of the module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 var url = require("url");
 var fs = require("fs");
+var Mincer = require("mincer");
 var Assets = require("./lib/assets");
 
 var connectAssets = module.exports = function (options, configureCallback) {
   options = parseOptions(options || {});
 
-  var assets = new Assets(options);
+  var assets = new Assets(Mincer, options);
   var compilationComplete = false;
   var compilationError;
   var waiting = [];
@@ -54,6 +55,8 @@ var connectAssets = module.exports = function (options, configureCallback) {
 
   return middleware;
 };
+
+module.exports.Mincer = Mincer
 
 var parseOptions = module.exports._parseOptions = function (options) {
   var isProduction = process.env.NODE_ENV === "production";

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,15 +1,19 @@
-var mincer = require("mincer");
 var url = require("url");
 var http = require("http");
 var fs = require("fs");
 var pathModule = require("path");
 var mime = require("mime");
 
-var Assets = module.exports = function (options) {
+var Assets = module.exports = function (Mincer, options) {
+  if (!options) {
+    options = Mincer
+    Mincer = require('mincer')
+  }
+  
   this.options = options;
 
   if (this.options.compile) {
-    this.environment = new mincer.Environment();
+    this.environment = new Mincer.Environment();
 
     this.environment.ContextClass.defineAssetPath(this.helper(function (url) {
       return url;
@@ -27,11 +31,11 @@ var Assets = module.exports = function (options) {
     this.options.paths.forEach(this.environment.appendPath, this.environment);
 
     if (this.options.buildDir) {
-      this.manifest = new mincer.Manifest(this.environment, this.options.buildDir);
+      this.manifest = new Mincer.Manifest(this.environment, this.options.buildDir);
     }
   }
   else {
-    this.manifest = new mincer.Manifest(null, this.options.buildDir);
+    this.manifest = new Mincer.Manifest(null, this.options.buildDir);
   }
 };
 


### PR DESCRIPTION
This change exposes Mincer outside of the module to allow for changes to Mincer (e.g. registering an engine (#303)). It solves the same problem as #330, but without requiring an additional callback.

```
var assets = require('connect-assets')
require('mincer-babel')(assets.Mincer)

app.use(assets())
```