### PR TITLE
update mincer to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-assets",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": "Andrew Dunkman <andrew@dunkman.org>",
   "description": "A Rails-like asset pipeline for Connect",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "argparse": "1.0.2",
     "csswring": "3.0.5",
     "mime": "1.3.4",
-    "mincer": "1.3.0",
+    "mincer": "1.4.0",
     "uglify-js": "2.4.23"
   },
   "devDependencies": {


### PR DESCRIPTION
`mincer@1.4.0` references `autoprefixer` instead of the deprecated [`autoprefixer-core`](https://github.com/ai/autoprefixer-core). Also bumped version to `5.0.2` for convenience (I hope!).

Please see related `mincer` [changelog](https://github.com/nodeca/mincer/blob/master/HISTORY.md#140--2015-10-24) for more information.

Thanks and keep up the great work!