### PR TITLE
Bump Mincer version for Sass SourceMaps

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -94,7 +94,7 @@ Assets.prototype.serveAsset = function (req, res, next) {
       if (!asset || !asset.sourceMap) {
         return next();
       }
-      res.setHeader("Content-Length", asset.sourceMap.length);
+      res.setHeader("Content-Length", Buffer.byteLength(asset.sourceMap, 'utf8'));
       res.setHeader("Content-Type", "application/json");
       return res.end(asset.sourceMap);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-assets",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": "Andrew Dunkman <andrew@dunkman.org>",
   "description": "A Rails-like asset pipeline for Connect",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "argparse": "1.0.2",
     "csswring": "3.0.5",
     "mime": "1.3.4",
-    "mincer": "1.3.0",
+    "mincer": "1.3.1",
     "uglify-js": "2.4.23"
   },
   "devDependencies": {

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -93,7 +93,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-0589f66713bc44029a1a720b9a0d850d.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-b2d7f14c5810c3ee6b519c317297190e.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -108,7 +108,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-0589f66713bc44029a1a720b9a0d850d.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-b2d7f14c5810c3ee6b519c317297190e.css\"");
       rmrf("builtAssets", done);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,7 +57,7 @@ describe("helper functions", function () {
     var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprinting: true });
     var files = ctx.assetPath("blank.css");
 
-    expect(files).to.equal("/assets/blank-0589f66713bc44029a1a720b9a0d850d.css");
+    expect(files).to.equal("/assets/blank-b2d7f14c5810c3ee6b519c317297190e.css");
   });
 
   describe("css", function () {

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -13,14 +13,14 @@ describe("serveAsset asset_path environment helper", function () {
 
     createServer.call(this, { buildDir: dir, compile: true, fingerprinting: true }, function () {
       var path = this.assetPath("asset-path-helper.css");
-      var filename = dir + "/asset-path-helper-791d4908176a09d310ccc381f9306283.css";
+      var filename = dir + "/asset-path-helper-c7c84865f023738e66a7b02353c5d6c3.css";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-0589f66713bc44029a1a720b9a0d850d.css\";\n\n");
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-b2d7f14c5810c3ee6b519c317297190e.css\";\n\n");
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -67,7 +67,7 @@ describe("serveAsset filesystem", function () {
         http.get(url, function (res) {
           expect(res.statusCode).to.equal(200);
           expect(fs.statSync(dir).isDirectory()).to.equal(true);
-          expect(fs.statSync(dir + "/blank-198068b3cdca651ae033a746f970a50d.css").isFile()).to.equal(true);
+          expect(fs.statSync(dir + "/blank-54acb57afb70110fb7f8e1de35e176b4.css").isFile()).to.equal(true);
 
           process.env.NODE_ENV = env;
           rmrf(dir, done);

--- a/test/serveAsset.minification.js
+++ b/test/serveAsset.minification.js
@@ -14,7 +14,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.js");
-      var filename = dir + "/unminified-b563e4856c147f0133a59fc9a7e4ee63.js";
+      var filename = dir + "/unminified-1e56447a8040d5d20e645c14b60843d3.js";
       var url = this.host + path;
 
       http.get(url, function (res) {
@@ -36,7 +36,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.css");
-      var filename = dir + "/unminified-c0389bd8003d3a89098cdb90e49209c3.css";
+      var filename = dir + "/unminified-918ac6d6065eb5d5579144f3444e13f2.css";
       var url = this.host + path;
 
       http.get(url, function (res) {


### PR DESCRIPTION
This also has a fix for source map content being cut off because of the `content-length` header not getting calculated correctly.