### PR TITLE
Upgrade mincer to 1.4.1, add postcss, fix assets digests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-assets",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": "Andrew Dunkman <andrew@dunkman.org>",
   "description": "A Rails-like asset pipeline for Connect",
   "license": "MIT",
@@ -38,7 +38,8 @@
     "argparse": "1.0.2",
     "csswring": "3.0.5",
     "mime": "1.3.4",
-    "mincer": "1.3.0",
+    "mincer": "1.4.1",
+    "postcss": "^5.0.19",
     "uglify-js": "2.4.23"
   },
   "devDependencies": {

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -93,7 +93,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-0589f66713bc44029a1a720b9a0d850d.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -108,7 +108,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-0589f66713bc44029a1a720b9a0d850d.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
       rmrf("builtAssets", done);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,7 +57,7 @@ describe("helper functions", function () {
     var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprinting: true });
     var files = ctx.assetPath("blank.css");
 
-    expect(files).to.equal("/assets/blank-0589f66713bc44029a1a720b9a0d850d.css");
+    expect(files).to.equal("/assets/blank-e89e45b0019f8d3feb5341de6b815cdb.css");
   });
 
   describe("css", function () {

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -13,14 +13,14 @@ describe("serveAsset asset_path environment helper", function () {
 
     createServer.call(this, { buildDir: dir, compile: true, fingerprinting: true }, function () {
       var path = this.assetPath("asset-path-helper.css");
-      var filename = dir + "/asset-path-helper-791d4908176a09d310ccc381f9306283.css";
+      var filename = dir + "/asset-path-helper-ecc5d891145d56a0274eb4f34670671e.css";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-0589f66713bc44029a1a720b9a0d850d.css\";\n\n");
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\";\n\n");
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -67,7 +67,7 @@ describe("serveAsset filesystem", function () {
         http.get(url, function (res) {
           expect(res.statusCode).to.equal(200);
           expect(fs.statSync(dir).isDirectory()).to.equal(true);
-          expect(fs.statSync(dir + "/blank-198068b3cdca651ae033a746f970a50d.css").isFile()).to.equal(true);
+          expect(fs.statSync(dir + "/blank-1e6dbfaaa068a191cfd257c013ddd699.css").isFile()).to.equal(true);
 
           process.env.NODE_ENV = env;
           rmrf(dir, done);

--- a/test/serveAsset.minification.js
+++ b/test/serveAsset.minification.js
@@ -14,7 +14,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.js");
-      var filename = dir + "/unminified-b563e4856c147f0133a59fc9a7e4ee63.js";
+      var filename = dir + "/unminified-7f7c719c7128b10ce7400464787a795c.js";
       var url = this.host + path;
 
       http.get(url, function (res) {
@@ -36,7 +36,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.css");
-      var filename = dir + "/unminified-c0389bd8003d3a89098cdb90e49209c3.css";
+      var filename = dir + "/unminified-f34e2abf5b7497977195904e60f06031.css";
       var url = this.host + path;
 
       http.get(url, function (res) {


### PR DESCRIPTION
Related to https://github.com/adunkman/connect-assets/pull/332 and https://github.com/adunkman/connect-assets/issues/333.

> 
> As the title says, the current mincer@1.3.0 dependency references deprecated autoprefixer-core. This results in project using connect-assets with autoprefixer functionality having to list the deprecated library as one of the dependencies.
> 
> The latest mincer@1.4.0 now references autoprefixer (the current official repo & module name). Please see related mincer [changelog](https://github.com/nodeca/mincer/blob/master/HISTORY.md#140--2015-10-24) for more information.

/cc @codynguyen 

1. If I get this right, tests were failing due to old asset digests (calculated `mincer@1.3.0`), which depend on current version of `mincer` ([here is how it's being done](https://github.com/nodeca/mincer/blob/master/lib/mincer/base.js#L131)) and should be updated when bumping mincer version.
2. `postcss` is now [required](https://github.com/nodeca/mincer/blob/master/HISTORY.md#130--2015-06-24) to have compatibility with new API of `autoprefixer`/`csswring`, old API support was dropped in [`mincer@1.4.0`](https://github.com/nodeca/mincer/blob/master/HISTORY.md#140--2015-10-24)