### PR TITLE
generate STYLE/SCRIPT tags with inline content

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,9 @@ var connectAssets = module.exports = function (options, configureCallback) {
   options.helperContext.js = assets.helper(tagWriters.js, "js");
   options.helperContext.assetPath = assets.helper(tagWriters.noop);
 
+  options.helperContext.css_inline = assets.helperInline(tagWriters.css_inline);
+  options.helperContext.js_inline  = assets.helperInline(tagWriters.js_inline);
+
   if (configureCallback) {
     configureCallback(assets);
   }
@@ -101,5 +104,8 @@ var parseUrl = function (string) {
 var tagWriters = {
   css: function (url, attr) { return '<link rel="stylesheet" href="' + url + '"' + pasteAttr(attr) + ' />'; },
   js: function (url, attr) { return '<script src="' + url + '"' + pasteAttr(attr) + '></script>'; },
-  noop: function (url) { return url; }
+  noop: function (url) { return url; },
+
+  css_inline: function (buffer, attr) { return '<style'  + pasteAttr(attr) + '>' + buffer + '</style>';  },
+  js_inline : function (buffer, attr) { return '<script' + pasteAttr(attr) + '>' + buffer + '</script>'; },
 };

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -9,7 +9,7 @@ var Assets = module.exports = function (Mincer, options) {
     options = Mincer
     Mincer = require('mincer')
   }
-  
+
   this.options = options;
 
   if (this.options.compile) {
@@ -210,6 +210,30 @@ Assets.prototype.helper = function (tagWriter, ext) {
     else {
       return getTag(asset);
     }
+  };
+};
+
+Assets.prototype.helperInline   = function (tagWriter, ext) {
+  var instance = this,
+      extRE    = new RegExp("\\." + ext + "$")
+  ;
+
+  return function (given, options) {
+    var asset, path;
+
+    path = (ext && !extRE.test(given))
+         ? given + "." + ext
+         : given
+         ;
+
+    try {
+      asset = instance.getAssetByPath(path, { bundle: true });
+    } catch (err) {}
+
+    if (!asset)
+      throw new Error("Asset '" + path + "' not found");
+
+    return tagWriter(asset.buffer, parseAttributes(options));
   };
 };
 

--- a/test/inlineHelpers.js
+++ b/test/inlineHelpers.js
@@ -1,0 +1,87 @@
+var expect = require("expect.js");
+var mocha = require("mocha");
+var assets = require("..");
+
+describe("inline-helper functions", function () {
+  it("do not pollute global scope if helperContext is passed", function () {
+    var ctx = {};
+    var instance = assets({ helperContext: ctx });
+
+    expect(ctx.css_inline).to.be.a("function");
+    expect(ctx.js_inline).to.be.a("function");
+
+    expect(global.css_inline).to.equal(undefined);
+    expect(global.js_inline).to.equal(undefined);
+  });
+
+  describe("css", function () {
+    it("throw an Error if asset is not found", function () {
+      var ctx = {};
+      var instance = assets({ helperContext: ctx });
+
+      expect(function () {
+        ctx.js_inline("non-existant-asset.js");
+      }).to.throwError(/'non-existant-asset.js' not found/i);
+    });
+
+    it("returns a <style> tag", function () {
+      var ctx      = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var tag      = ctx.css_inline("unminified.css");
+
+      expect(tag).to.match(/<style>([\s\S]+?)<\/style>/m);
+    });
+
+    it("should serve correct asset even if extention is not supplied", function () {
+      var ctx      = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var tag      = ctx.css_inline("unminified");
+
+      expect(tag).to.match(/<style>([\s\S]+?)<\/style>/m);
+    });
+
+    it("should have additional attributes in result tag", function () {
+      var ctx      = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/css" });
+      var tag      = ctx.css_inline("asset.css", { 'data-turbolinks-track': true });
+
+      expect(tag).to.match(/data-turbolinks-track>/);
+    });
+  });
+
+  describe("js", function () {
+    it("throw an Error if asset is not found", function () {
+      var ctx = {};
+      var instance = assets({ helperContext: ctx });
+
+      expect(function () {
+        ctx.js_inline("non-existant-asset.js");
+      }).to.throwError(/'non-existant-asset.js' not found/i);
+    });
+
+    it("returns a <style> tag", function () {
+      var ctx      = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var tag      = ctx.js_inline("simple.js");
+
+      expect(tag).to.match(/<script>var a = true;<\/script>/m);
+    });
+
+    it("should serve correct asset even if extention is not supplied", function () {
+      var ctx      = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var tag      = ctx.js_inline("simple");
+
+      expect(tag).to.match(/<script>var a = true;<\/script>/m);
+    });
+
+    it("should have additional attributes in result tag", function () {
+      var ctx      = {};
+      var instance = assets({ helperContext: ctx, paths: "test/assets/js" });
+      var tag      = ctx.js_inline("unminified.js", { 'data-turbolinks-track': true });
+
+      expect(tag).to.match(/data-turbolinks-track>/);
+    });
+  });
+
+});


### PR DESCRIPTION
hi there,

I am using connect-assets already and I needed a way to include JS and/or CSS inline in order to implement a page according to the [AMP spec](https://www.ampproject.org/docs/get_started/about-amp.html)

I created this basic PR (incl. a couple of tests) to solve my initial problem. You might want to include it but I imagine that it requires a bit more work (e.g. with regard to handling bundled assets), if you're interested please advise what might need to be done in order to get it merged. 

