### PR TITLE
Add embedMappingComments option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ app.use(assets({
 ```
 You can then use the `assetPath` helper in your Jade like so:
 ```
-img(src="#{assetPath('image-name.png')}") 
+img(src="#{assetPath('image-name.png')}")
 ```
 
 Would result in:
@@ -201,8 +201,8 @@ Optional arguments:
                         assets will be read from, in order of preference.
                         Defaults to 'assets/js' and 'assets/css'.
   -c [FILE [FILE ...]], --compile [FILE [FILE ...]]
-                        Adds the file (or pattern) to a list of files to 
-                        compile. Defaults to all files with extensions. Only 
+                        Adds the file (or pattern) to a list of files to
+                        compile. Defaults to all files with extensions. Only
                         include the left most extension (ex. main.css).
   -o DIRECTORY, --output DIRECTORY
                         Specifies the output directory to write compiled
@@ -217,6 +217,8 @@ Optional arguments:
                         default.
   -ap, --autoprefixer   Enables autoprefixer during compilation.
   -sm, --sourceMaps     Enables source map generation for all files.
+  -emc, --embedMappingComments
+                        Embed source map url into compiled files
 ```
 
 ## Credits

--- a/bin/connect-assets
+++ b/bin/connect-assets
@@ -69,6 +69,12 @@ var initialize = exports.initialize = function () {
     defaultValue: false
   });
 
+  cli.addArgument(["-emc", "--embedMappingComments"], {
+    help: "Embed source map url into compiled files",
+    action: 'storeTrue',
+    defaultValue: false
+  });
+
   return cli;
 };
 
@@ -137,7 +143,8 @@ var _compile = exports._compile = function (args, callback) {
     servePath: args.servePath,
     precompile: args.compile,
     fingerprinting: true,
-    sourceMaps: args.sourceMaps
+    sourceMaps: args.sourceMaps,
+    embedMappingComments: args.embedMappingComments
   });
 
   if (args.autoprefixer) { assets.environment.enable('autoprefixer'); }

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -48,7 +48,8 @@ Assets.prototype.compile = function (callback) {
     try {
       var manifestObj = this.manifest.compile(this.options.precompile, {
         compress: this.options.gzip,
-        sourceMaps: this.options.sourceMaps
+        sourceMaps: this.options.sourceMaps,
+        embedMappingComments: this.options.embedMappingComments
       });
       callback(null, manifestObj);
     }

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -126,4 +126,20 @@ describe("connect-assets command-line interface", function () {
       rmrf("builtAssets", done);
     });
   });
+
+  it("embeds mapping comments in compiled files", function (done) {
+    var argv = process.argv;
+    var dir = "builtAssets";
+    process.argv = "node connect-assets -sm -emc -i test/assets/js".split(" ");
+
+    bin.execute(this.logger, function (manifest) {
+      process.argv = argv;
+
+      var js = dir + '/' + manifest.assets['unminified.js'];
+      var mapping = "//# sourceMappingURL=" +  manifest.assets['unminified.js'] + ".map"
+
+      expect(fs.readFileSync(js, "utf8")).to.contain(mapping);
+      rmrf("builtAssets", done);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds the options `--embedMappingComments` (`-emc` for short) to the CLI to enable the mapping comments (`//# sourceMappingURL=path/to/js.map`) in the compiled files.

Related: https://github.com/adunkman/connect-assets/issues/345