### PR TITLE
Add CLI option to skip XSSI protection header for source map files

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ Optional arguments:
   -ap, --autoprefixer   Enables autoprefixer during compilation.
   -sm, --sourceMaps     Enables source map generation for all files.
   -emc, --embedMappingComments
-                        Embed source map url into compiled files
+                        Embed source map url into compiled files.
+  -nsmp, --noSourceMapProtection
+                        Do not add XSSI protection header to source map files.
+                        https://github.com/adunkman/connect-assets/issues/345#issuecomment-235246691
 ```
 
 ## Credits

--- a/bin/connect-assets
+++ b/bin/connect-assets
@@ -75,6 +75,12 @@ var initialize = exports.initialize = function () {
     defaultValue: false
   });
 
+  cli.addArgument(["-nsmp", "--noSourceMapProtection"], {
+    help: "Do not add XSSI protection header to source map files",
+    action: 'storeTrue',
+    defaultValue: false
+  });
+
   return cli;
 };
 
@@ -144,7 +150,8 @@ var _compile = exports._compile = function (args, callback) {
     precompile: args.compile,
     fingerprinting: true,
     sourceMaps: args.sourceMaps,
-    embedMappingComments: args.embedMappingComments
+    embedMappingComments: args.embedMappingComments,
+    noSourceMapProtection: args.noSourceMapProtection
   });
 
   if (args.autoprefixer) { assets.environment.enable('autoprefixer'); }

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -49,7 +49,8 @@ Assets.prototype.compile = function (callback) {
       var manifestObj = this.manifest.compile(this.options.precompile, {
         compress: this.options.gzip,
         sourceMaps: this.options.sourceMaps,
-        embedMappingComments: this.options.embedMappingComments
+        embedMappingComments: this.options.embedMappingComments,
+        noSourceMapProtection: this.options.noSourceMapProtection
       });
       callback(null, manifestObj);
     }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "argparse": "1.0.7",
     "csswring": "5.0.0",
     "mime": "1.3.4",
-    "mincer": "1.4.1",
+    "mincer": "1.4.2",
     "postcss": "5.0.21",
     "uglify-js": "2.6.2"
   },

--- a/test/bin.connect-assets.js
+++ b/test/bin.connect-assets.js
@@ -93,7 +93,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"/assets/asset-8f0b23b09147d215614e46ea1922e0c3.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -108,7 +108,7 @@ describe("connect-assets command-line interface", function () {
 
       var css = dir + '/' + manifest.assets['asset-path-helper.css'];
 
-      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-e89e45b0019f8d3feb5341de6b815cdb.css\"");
+      expect(fs.readFileSync(css, "utf8")).to.equal("@import\"//cdn.example.com/asset-8f0b23b09147d215614e46ea1922e0c3.css\"");
       rmrf("builtAssets", done);
     });
   });
@@ -123,6 +123,20 @@ describe("connect-assets command-line interface", function () {
 
       var map = dir + '/' + manifest.assets['unminified.js'] + '.map';
       expect(fs.readFileSync(map, "utf8")).to.equal(")]}\'\n{\"version\":3,\"sources\":[\"test/assets/js/unminified.js\"],\"names\":[\"aVeryLongVariableName\",\"someFunctions\",\"aLongKeyName\"],\"mappings\":\"CAAA,WACA,GAAAA,GAAA,WAEAC,GACAC,aAAA,WACA,MAAAF,IAGAC,GAAAC\",\"file\":\"unminified.js\",\"sourcesContent\":[\"(function () {\\n  var aVeryLongVariableName = \\\"A string\\\";\\n\\n  var someFunctions = {\\n    aLongKeyName: function () {\\n      return aVeryLongVariableName;\\n    }\\n  };\\n  var x = someFunctions.aLongKeyName();\\n})();\"],\"sourceRoot\":\"/\"}");
+      rmrf("builtAssets", done);
+    });
+  });
+
+  it("generates source maps without XSSI protection header when noSourceMapProtection option defined", function (done) {
+    var argv = process.argv;
+    var dir = "builtAssets";
+    process.argv = "node connect-assets -sm -nsmp -i test/assets/js".split(" ");
+
+    bin.execute(this.logger, function (manifest) {
+      process.argv = argv;
+
+      var map = dir + '/' + manifest.assets['unminified.js'] + '.map';
+      expect(fs.readFileSync(map, "utf8")).to.equal("{\"version\":3,\"sources\":[\"test/assets/js/unminified.js\"],\"names\":[\"aVeryLongVariableName\",\"someFunctions\",\"aLongKeyName\"],\"mappings\":\"CAAA,WACA,GAAAA,GAAA,WAEAC,GACAC,aAAA,WACA,MAAAF,IAGAC,GAAAC\",\"file\":\"unminified.js\",\"sourcesContent\":[\"(function () {\\n  var aVeryLongVariableName = \\\"A string\\\";\\n\\n  var someFunctions = {\\n    aLongKeyName: function () {\\n      return aVeryLongVariableName;\\n    }\\n  };\\n  var x = someFunctions.aLongKeyName();\\n})();\"],\"sourceRoot\":\"/\"}");
       rmrf("builtAssets", done);
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -62,7 +62,7 @@ describe("helper functions", function () {
     var instance = assets({ helperContext: ctx, paths: "test/assets/css", fingerprinting: true });
     var files = ctx.assetPath("blank.css");
 
-    expect(files).to.equal("/assets/blank-e89e45b0019f8d3feb5341de6b815cdb.css");
+    expect(files).to.equal("/assets/blank-8f0b23b09147d215614e46ea1922e0c3.css");
   });
 
   describe("css", function () {
@@ -206,7 +206,7 @@ describe("helper functions", function () {
       var tag = ctx.jsInline("depends-on-blank.js");
       expect(tag).to.equal("<script>\n;\n//(=) require blank\n;\n</script>");
     });
-    
+
     it("should serve asset from manifest", function (done) {
       var dir = "testBuiltAssets";
       var ctx = {};

--- a/test/serveAsset.asset_path-helper.js
+++ b/test/serveAsset.asset_path-helper.js
@@ -13,14 +13,14 @@ describe("serveAsset asset_path environment helper", function () {
 
     createServer.call(this, { build: true, buildDir: dir, compile: true, fingerprinting: true }, function () {
       var path = this.assetPath("asset-path-helper.css");
-      var filename = dir + "/asset-path-helper-ecc5d891145d56a0274eb4f34670671e.css";
+      var filename = dir + "/asset-path-helper-609b633273448486315f45ff33175f8c.css";
       var url = this.host + path;
 
       http.get(url, function (res) {
         expect(res.statusCode).to.equal(200);
         expect(fs.statSync(dir).isDirectory()).to.equal(true);
         expect(fs.statSync(filename).isFile()).to.equal(true);
-        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-e89e45b0019f8d3feb5341de6b815cdb.css\";\n\n");
+        expect(fs.readFileSync(filename, "utf8")).to.equal("@import \"/assets/asset-8f0b23b09147d215614e46ea1922e0c3.css\";\n\n");
 
         process.env.NODE_ENV = env;
         rmrf(dir, done);

--- a/test/serveAsset.filesystem.js
+++ b/test/serveAsset.filesystem.js
@@ -67,7 +67,7 @@ describe("serveAsset filesystem", function () {
         http.get(url, function (res) {
           expect(res.statusCode).to.equal(200);
           expect(fs.statSync(dir).isDirectory()).to.equal(true);
-          expect(fs.statSync(dir + "/blank-1e6dbfaaa068a191cfd257c013ddd699.css").isFile()).to.equal(true);
+          expect(fs.statSync(dir + "/blank-17b7ffb6cc1f3588d20dda49ffb651f0.css").isFile()).to.equal(true);
 
           process.env.NODE_ENV = env;
           rmrf(dir, done);

--- a/test/serveAsset.minification.js
+++ b/test/serveAsset.minification.js
@@ -14,7 +14,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.js");
-      var filename = dir + "/unminified-7f7c719c7128b10ce7400464787a795c.js";
+      var filename = dir + "/unminified-71fbd47d95e567ed083f0c1220c114d7.js";
       var url = this.host + path;
 
       http.get(url, function (res) {
@@ -36,7 +36,7 @@ describe("serveAsset minification", function () {
 
     createServer.call(this, { buildDir: dir }, function () {
       var path = this.assetPath("unminified.css");
-      var filename = dir + "/unminified-f34e2abf5b7497977195904e60f06031.css";
+      var filename = dir + "/unminified-68621ef2624992e191af9888d43b4346.css";
       var url = this.host + path;
 
       http.get(url, function (res) {


### PR DESCRIPTION
Currently a XSSI protection header (the string  `)]}'\n`) is added to generated source map files by default.

However, for cases where source map files are NOT to be served via HTTP, the protection header does not make sense and can cause problem for some source map reader.

This PR adds the CLI option `--noSourceMapProtection` (`-nsmp` for short) to allow user to skip adding the protection header to the generated source map files.

Original discussion: https://github.com/adunkman/connect-assets/issues/345#issuecomment-235246691